### PR TITLE
Add version to the yaml arquives

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -9,6 +9,8 @@
 # This is a lightweight configuration with Zeebe, Operate, Tasklist, and Elasticsearch
 # See docker-compose.yml for a configuration that also includes Optimize, Identity, and Keycloak.
 
+version: "1"
+
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@
 # This is a full configuration with Zeebe, Operate, Tasklist, Optimize, Identity, Keycloak, and Elasticsearch
 # See docker-compose-core.yml for a lightweight configuration that does not include Optimize, Identity, and Keycloak.
 
+version: "1"
+
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe


### PR DESCRIPTION
When I use the docker-compose occurs a error:
ERROR: The Compose file './docker-compose-core.yaml' is invalid because:
Unsupported config option for networks: 'camunda-platform'
Unsupported config option for volumes: 'elastic'
Unsupported config option for services: 'tasklist'
Which is corrected by putting a version in the yaml arquives