### PR TITLE
fix(optimize): update to 3.8.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
       - elasticsearch
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
-    image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION:-3.8.1}
+    image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION:-3.8.2}
     container_name: optimize
     ports:
       - "8083:8090"


### PR DESCRIPTION
- 3.8.1 didn't startup in CCSM due to a bug https://jira.camunda.com/browse/OPT-6183

relates to #OPT-6183