### PR TITLE
disable security for ElasticSearch

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -72,6 +72,7 @@ services:
     environment:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
+      - xpack.security.enabled=false
       # allow running with low disk space
       - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
To avoid the flood of warnings in the logs

closes #17 