### PR TITLE
Allow insecure connection to ElasticSearch

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -163,6 +163,7 @@ services:
     environment:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
+      - xpack.security.enabled=false
       # allow running with low disk space
       - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
As done already for docker-compose-core, this setting will reduce the log size and supress all hints to insecure ElasticSearch connections for the second setup.