### PR TITLE
fix: update keycloak image to align with Helm charts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,6 +120,7 @@ services:
       - "8084:8084"
     environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
       SERVER_PORT: 8084
+      IDENTITY_RETRY_DELAY_SECONDS: 30
       KEYCLOAK_URL: http://keycloak:8080/auth
       IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
       KEYCLOAK_INIT_OPERATE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
@@ -141,16 +142,34 @@ services:
     depends_on:
       - keycloak
 
-  keycloak: # https://hub.docker.com/r/jboss/keycloak
+  postgres: # https://hub.docker.com/_/postgres
+    container_name: keycloak-postgres
+    image: postgres:${POSTGRES_VERSION:-14.5-alpine}
+    environment:
+      POSTGRES_DB: bitnami_keycloak
+      POSTGRES_USER: bn_keycloak
+      POSTGRES_PASSWORD: "#3$]O?4RGj)DE7Z!9SA5"
+
+  keycloak: # https://hub.docker.com/r/bitnami/keycloak
+    depends_on:
+      - postgres
     container_name: keycloak
-    image: jboss/keycloak:${KEYCLOAK_VERSION:-16.1.1}
+    image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION:-16.1.1}
+    volumes:
+      - ./keycloak/themes/identity:/opt/bitnami/keycloak/themes/identity
     ports:
       - "18080:8080"
     environment:
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: admin
-    volumes:
-      - "./.keycloak/themes/identity:/opt/jboss/keycloak/themes/identity"
+      KEYCLOAK_DATABASE_HOST: keycloak-postgres
+      KEYCLOAK_DATABASE_PASSWORD: "#3$]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_ADMIN_USER: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9990/health" ]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
     networks:
       - identity-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,16 +143,24 @@ services:
       - keycloak
 
   postgres: # https://hub.docker.com/_/postgres
-    container_name: keycloak-postgres
+    container_name: postgres
     image: postgres:${POSTGRES_VERSION:-14.5-alpine}
     environment:
       POSTGRES_DB: bitnami_keycloak
       POSTGRES_USER: bn_keycloak
-      POSTGRES_PASSWORD: "#3$]O?4RGj)DE7Z!9SA5"
+      POSTGRES_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres:/usr/local/postgres/data
+    networks:
+      - identity-network
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
-    depends_on:
-      - postgres
     container_name: keycloak
     image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION:-16.1.1}
     volumes:
@@ -161,9 +169,10 @@ services:
       - "18080:8080"
     environment:
       KEYCLOAK_DATABASE_HOST: keycloak-postgres
-      KEYCLOAK_DATABASE_PASSWORD: "#3$]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
       KEYCLOAK_ADMIN_USER: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+    restart: on-failure
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9990/health" ]
       interval: 30s
@@ -172,6 +181,8 @@ services:
       start_period: 30s
     networks:
       - identity-network
+    depends_on:
+      - postgres
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.17.0}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,11 +164,11 @@ services:
     container_name: keycloak
     image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION:-16.1.1}
     volumes:
-      - ./keycloak/themes/identity:/opt/bitnami/keycloak/themes/identity
+      - ./.keycloak/themes/identity:/opt/bitnami/keycloak/themes/identity
     ports:
       - "18080:8080"
     environment:
-      KEYCLOAK_DATABASE_HOST: keycloak-postgres
+      KEYCLOAK_DATABASE_HOST: postgres
       KEYCLOAK_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
       KEYCLOAK_ADMIN_USER: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -214,6 +214,7 @@ services:
 volumes:
   zeebe:
   elastic:
+  postgres:
 
 networks:
   # Note there are two bridge networks: One for Camunda Platform and one for Identity.


### PR DESCRIPTION
To align with the Camunda Helm charts and also how Identity is used internally this PR updates the Keycloak image used to the Bitnami offering (which also requires a postgres container).