### PR TITLE
Add connectors bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The full enviornment contains these components:
 - Zeebe
 - Operate
 - Tasklist
+- Connectors
 - Optimize
 - Identity
 - Elasticsearch
@@ -63,6 +64,20 @@ In addition to the local environment setup with docker-compose, you can download
 
 Feedback and updates are welcome!
 
+## Connectors
+
+Both docker-compose files contain our [out-of-the-box Connectors](https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/).
+
+To inject secrets into the Connector runtime they can be added to the
+[`connector-secrets.txt`](connector-secrets.txt) file inside the repository in the format `NAME=VALUE`
+per line. The secrets will then be available in the Connector runtime with the
+format `secrets.NAME`.
+
+To add custom Connectors either create a new docker image bundling them as
+described [here](https://github.com/camunda/connector-sdk/tree/main/runtime-job-worker#docker-job-worker-runtime-image).
+
+Alternatively, you can mount new Connector JARs as volumes into the `/opt/app` folder by adding this to the docker-compose file. Keep in mind that the Connector JARs need to bring along all necessary dependencies inside the JAR.
+
 ## Web Modeler Self-Managed Beta Release
 
 > :warning: Web Modeler Self-Managed is currently offered as a [beta release](https://docs.camunda.io/docs/next/reference/early-access#beta) with limited availability for enterprise customers only. It is not recommended for production use, and there is no maintenance service guaranteed. Special [terms & conditions](https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-self-managed/) apply. However, we encourage you to provide feedback via your designated support channel or the [Camunda Forum](https://forum.camunda.io/).
@@ -90,8 +105,6 @@ Once you are ready to deploy or execute processes use these settings to deploy t
 The setup includes [MailHog](https://github.com/mailhog/MailHog) as a test SMTP server. It captures all emails sent by Web Modeler, but does not forward them to the actual recipients. 
 
 You can access emails in MailHog's Web UI at [http://localhost:8075](http://localhost:8075).
-
-
 
 # Camunda Platform 7
 

--- a/connector-secrets.txt
+++ b/connector-secrets.txt
@@ -1,0 +1,2 @@
+# add secrets per line in the format NAME=VALUE
+# WARNING: ensure not to commit changes to this file

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -63,6 +63,18 @@ services:
       - zeebe
       - elasticsearch
 
+  connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.1.0}
+    container_name: connectors
+    environment:
+      - ZEEBE_ADDRESS=zeebe:26500
+      - ZEEBE_INSECURE=true
+    env_file: connector-secrets.txt
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.17.5}
     container_name: elasticsearch

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - identity
       - elasticsearch
 
+  connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.1.0}
+    container_name: connectors
+    environment:
+      - ZEEBE_ADDRESS=zeebe:26500
+      - ZEEBE_INSECURE=true
+    env_file: connector-secrets.txt
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION:-3.9.0}
     container_name: optimize


### PR DESCRIPTION
- adds connectors bundle to the core and full distribution
- connectors bundle contains all out-of-the-box connectors for Camunda 8
- add connector-secrets.txt file to inject secrets into the environment
- update README with description of the connectors

closes #34