### PR TITLE
Rename dev profile to kibana

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,21 @@ described [here](https://github.com/camunda/connector-sdk/tree/main/runtime-job-
 
 Alternatively, you can mount new Connector JARs as volumes into the `/opt/app` folder by adding this to the docker-compose file. Keep in mind that the Connector JARs need to bring along all necessary dependencies inside the JAR.
 
-## Development
+## Kibana
 
-A `dev` profile is available to support troubleshooting in the provided docker compose files.
-It can be enabled by adding `--profile dev` to your docker compose command.
-In addition to the other components, this profile spins up Kibana which can be used to explore the records exported into Elasticsearch.
+A `kibana` profile is available in the provided docker compose files to support inspection and exploration of the Camunda Platform 8 data in Elasticsearch.
+It can be enabled by adding `--profile kibana` to your docker compose command.
+In addition to the other components, this profile spins up [Kibana](https://www.elastic.co/kibana/).
+Kibana can be used to explore the records exported by Zeebe into Elasticsearch, or to discover the data in Elasticsearch used by the other components (e.g. Operate).
 
-You can navigate to the Kibana web app and start exploring the log without login credentials:
+You can navigate to the Kibana web app and start exploring the data without login credentials:
 
 - Kibana: [http://localhost:5601](http://localhost:5601)
 
 > **Note**
-> You need to configure the index patterns in Kibana before you can explore the exported records.
+> You need to configure the index patterns in Kibana before you can explore the data.
 > - Go to `Management > Stack Management > Kibana > Index Patterns`.
-> - Create a new index pattern for `zeebe-record-*`.
+> - Create a new index pattern. For example, `zeebe-record-*` matches the exported records.
 >   - If you don't see any indexes then make sure to export some data first (e.g. deploy a process). The indexes of the records are created when the first record of this type is exported.
 > - Go to `Analytics > Discover` and select the index pattern.
 

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -115,7 +115,7 @@ services:
     depends_on:
       - elasticsearch
     profiles:
-      - dev
+      - kibana
 
 volumes:
   zeebe:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -250,7 +250,7 @@ services:
     depends_on:
       - elasticsearch
     profiles:
-      - dev
+      - kibana
 
 volumes:
   zeebe:


### PR DESCRIPTION
We expect that users will use this project for development purposes only. For production usage, they should use our helm charts. However, a section was added to the README about development, which is likely confusing. This section was about using Kibana to inspect, explore or troubleshoot the camunda platform record log in Elasticsearch. It could however also be used to explore the data of the other components (Operate, Tasklist, Optimize).

- This renames the profile to `kibana` to better reflect the usage. 
- It also improves the README to better convey what this profile can be used for. 
- Lastly, it updates the note about index patterns, as this was very specific to 1 of the use cases that Kibana can be used for.

closes #51 