### PR TITLE
docs: fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ per line. The secrets will then be available in the Connector runtime with the
 format `secrets.NAME`.
 
 To add custom Connectors either create a new docker image bundling them as
-described [here](https://github.com/camunda/connector-sdk/tree/main/runtime-job-worker#docker-job-worker-runtime-image).
+described [here](https://github.com/camunda/connector-sdk/tree/main/runtime#docker-job-worker-runtime-image).
 
 Alternatively, you can mount new Connector JARs as volumes into the `/opt/app` folder by adding this to the docker-compose file. Keep in mind that the Connector JARs need to bring along all necessary dependencies inside the JAR.
 


### PR DESCRIPTION
This PR fixes the broken link in [README.md](https://github.com/camunda/camunda-platform/blob/88ecbb6f373751d18fff6b35e4d9cc47b7cb6506/README.md?plain=1#L81).