### PR TITLE
chore: disable health endpoint for Keycloak

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -199,10 +199,9 @@ services:
       KEYCLOAK_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
       KEYCLOAK_ADMIN_USER: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KC_HEALTH_ENABLED: true
     restart: on-failure
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth" ]
       interval: 30s
       timeout: 15s
       retries: 5


### PR DESCRIPTION
With the update to Keycloak v19 in https://github.com/camunda/camunda-platform/pull/55 I have enabled the health endpoint according to https://github.com/camunda/camunda-platform/pull/55#discussion_r1010356644 which Keycloak now serves on the public port. According to [Keycloak docs](https://www.keycloak.org/server/reverseproxy) this endpoint should not be exposed publicly but rather protected by f.e. ingress path filtering. 

> Exposed health checks lead to an unnecessary attack vector.

This PR removes the exposure of health endpoint and just uses the `/auth` endpoint for checks