### PR TITLE
chore: add a Dockerfile for arm-based Keycloak

### DIFF
--- a/.keycloak/Dockerfile
+++ b/.keycloak/Dockerfile
@@ -1,0 +1,62 @@
+# This Dockerfile will build an arm64 Keycloak image that can be used in the same way
+# as the docker images provided by bitnami/keycloak
+ARG KEYCLOAK_VERSION=19.0.3
+
+# Inspired by https://github.com/keycloak/keycloak/blob/main/quarkus/container/Dockerfile
+# and https://github.com/bitnami/containers/blob/main/bitnami/keycloak/19/debian-11/Dockerfile
+FROM registry.access.redhat.com/ubi8-minimal AS build
+
+ARG KEYCLOAK_VERSION
+ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+
+RUN microdnf install -y tar gzip
+
+ADD $KEYCLOAK_DIST /tmp/keycloak/
+
+# The next step makes it uniform for local development and upstream built.
+# If it is a local tar archive then it is unpacked, if from remote is just downloaded.
+RUN (cd /tmp/keycloak && \
+    tar -xvf /tmp/keycloak/keycloak-*.tar.gz && \
+    rm /tmp/keycloak/keycloak-*.tar.gz) || true
+
+RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
+
+RUN chmod -R g+rwX /opt/keycloak
+
+FROM docker.io/bitnami/keycloak:${KEYCLOAK_VERSION} as bitnami-env
+
+FROM registry.access.redhat.com/ubi8-minimal
+ARG KEYCLOAK_VERSION
+ENV LANG en_US.UTF-8
+
+COPY --from=build --chown=1000:0 /opt/keycloak /opt/keycloak
+COPY --from=bitnami-env --chown=1000:0 /opt/bitnami/scripts /opt/bitnami/scripts
+RUN ln -s /opt/keycloak /opt/bitnami/keycloak
+
+# prevent JAVA_HOME from being changed
+RUN sed -i 's/export JAVA_HOME=\"\/opt\/bitnami\/java\"//' /opt/bitnami/scripts/keycloak-env.sh
+
+RUN microdnf update -y && \
+    microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en hostname tar gzip && microdnf clean all && rm -rf /var/cache/yum/* && \
+    echo "keycloak:x:0:root" >> /etc/group && \
+    echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
+
+# Install wait-for-port which is required by bitnami scripts
+# ref: https://github.com/bitnami/containers/blob/main/bitnami/keycloak/19/debian-11/Dockerfile#L25
+RUN \
+    curl -SsLf "https://github.com/bitnami/wait-for-port/releases/download/v1.0.5/wait-for-port-linux-arm64.tar.gz" -O && \
+    tar -zxf "wait-for-port-linux-arm64.tar.gz" && \
+    rm -rf "wait-for-port-linux-arm64.tar.gz" && \
+    mv ./wait-for-port-linux-arm64 /usr/bin/wait-for-port
+
+ENV APP_VERSION="$KEYCLOAK_VERSION" \
+    BITNAMI_APP_NAME="keycloak" \
+    PATH="/opt/bitnami/common/bin:/opt/bitnami/java/bin:/opt/bitnami/keycloak/bin:$PATH"
+
+USER 1000
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENTRYPOINT [ "/opt/bitnami/scripts/keycloak/entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/keycloak/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can access emails in MailHog's Web UI at [http://localhost:8075](http://loca
 # Troubleshooting
 ## Running on arm64 based hardware
 When using arm64-based hardware like a M1 or M2 Mac the Keycloak container might not start because Bitnami only
-provides amd64-based images. You can build and tag an arm-based image locally using following command. After building
+provides amd64-based images. You can build and tag an arm-based image locally using the following command. After building
 and tagging the image you can start the environment as described in [Using docker-compose](#using-docker-compose).
 
 ```

--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ You can access emails in MailHog's Web UI at [http://localhost:8075](http://loca
 # Troubleshooting
 ## Running on arm64 based hardware
 When using arm64-based hardware like a M1 or M2 Mac the Keycloak container might not start because Bitnami only
-provides amd64-based images. You can build and tag an arm-based image locally using the following command. After building
-and tagging the image you can start the environment as described in [Using docker-compose](#using-docker-compose).
+provides amd64-based images. Until bitnami adds
+[support for linux/arm64 images](https://github.com/bitnami/charts/issues/7305), you can build and tag an arm-based
+image locally using the following command. After building and tagging the image you can start the environment as
+described in [Using docker-compose](#using-docker-compose).
 
 ```
 $ DOCKER_BUILDKIT=0 docker build -t bitnami/keycloak:19.0.3 "https://github.com/camunda/camunda-platform.git#main:.keycloak/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The full enviornment contains these components:
 - Optimize
 - Identity
 - Elasticsearch
-- KeyCloak
+- Keycloak
 
 Clone this repo and issue the following command to start your environment:
 
@@ -43,8 +43,8 @@ Now you can navigate to the different web apps and log in with the user `demo` a
 - Identity: [http://localhost:8084](http://localhost:8084)
 - Elasticsearch: [http://localhost:9200](http://localhost:9200)
 
-KeyCloak is used to manage users. Here you can log in with the user `admin` and password `admin`
-- KeyCloak: [http://localhost:18080/auth/](http://localhost:18080/auth/)
+Keycloak is used to manage users. Here you can log in with the user `admin` and password `admin`
+- Keycloak: [http://localhost:18080/auth/](http://localhost:18080/auth/)
 
 The workflow engine Zeebe is available using gRPC at `localhost:26500`.
 
@@ -145,3 +145,13 @@ You can access emails in MailHog's Web UI at [http://localhost:8075](http://loca
 
 - [Documentation](https://docs.camunda.org/)
 - [GitHub](https://github.com/camunda/camunda-bpm-platform)
+
+# Troubleshooting
+## Running on arm64 based hardware
+When using arm64-based hardware like a M1 or M2 Mac the Keycloak container might not start because Bitnami only
+provides amd64-based images. You can build and tag an arm-based image locally using following command. After building
+and tagging the image you can start the environment as described in [Using docker-compose](#using-docker-compose).
+
+```
+$ DOCKER_BUILDKIT=0 docker build -t bitnami/keycloak:19.0.3 "https://github.com/camunda/camunda-platform.git#main:.keycloak/"
+```


### PR DESCRIPTION
Part of #21, Fixes https://github.com/camunda-cloud/identity/issues/1304

## Description
Provides a Dockerfile to build an arm64-based Keycloak image locally and respective documentation in the Readme.

## Context
Keycloak is an opensource project and there are multiple distributors providing docker images. We use Bitnami based image that are not available for arm64 yet [Ref](https://hub.docker.com/r/bitnami/keycloak/tags). There are Docker images for Keycloak 20.0+ available for arm at [hub.docker.com/r/keycloak/keycloak](https://hub.docker.com/r/keycloak/keycloak/tags) but these have different ENV variable naming and run configuration than the bitnami ones and are therefore not compatible with the docker-compose files included in this repository.

Although bitnami's [Dockerfile](https://github.com/bitnami/containers/blob/main/bitnami/keycloak/19/debian-11/Dockerfile) has a `TARGETARCH` argument that can be provided during build time, it can not be used as it is because the components it downloads are not uploaded as arm64 by bitnami.

The provided Dockerfile is a combination of https://github.com/keycloak/keycloak/blob/main/quarkus/container/Dockerfile and https://github.com/bitnami/containers/blob/main/bitnami/keycloak/19/debian-11/Dockerfile

The [docker build command provided in the Readme](https://github.com/camunda/camunda-platform/pull/67/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156) will directly use the Dockerfile from the `main` branch without the need to download the whole repository. Before these changes are merged to `main` the command can be tested by using the feature branch:

```
DOCKER_BUILDKIT=0 docker build -t bitnami/keycloak:19.0.3 "https://github.com/camunda/camunda-platform.git#keycloak/arm-build:.keycloak/"
```

