### PR TITLE
chore(connectors): specify platform for connectors which only supports amd64

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -66,6 +66,7 @@ services:
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.0}
     container_name: connectors
+    platform: linux/amd64
     environment:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
       - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.0}
     container_name: connectors
+    platform: linux/amd64
     ports:
       - "8085:8080"
     environment:


### PR DESCRIPTION
This may at least allow users on an arm platforms to run the compose stack, see https://github.com/camunda/product-hub/issues/222#issuecomment-1429977258.