### PR TITLE
chore(connectors): bump connectors-bundle to 0.16.1

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -64,7 +64,7 @@ services:
       - elasticsearch
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
-    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.0}
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.1}
     container_name: connectors
     environment:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
       - elasticsearch
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
-    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.0}
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION:-0.16.1}
     container_name: connectors
     ports:
       - "8085:8080"


### PR DESCRIPTION
Since 0.16.1, connectors images are multiplatform.