### PR TITLE
feat(zeebe): authentication config zeebe gateway

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,15 @@
+## Image versions ##
 CAMUNDA_CONNECTORS_VERSION=0.17.1
 CAMUNDA_OPTIMIZE_VERSION=3.10.0-alpha5
-CAMUNDA_PLATFORM_VERSION=8.2.0-alpha5
+CAMUNDA_PLATFORM_VERSION=SNAPSHOT
 CAMUNDA_WEB_MODELER_VERSION=0.8.0-beta
 ELASTIC_VERSION=7.17.5
 KEYCLOAK_SERVER_VERSION=19.0.3
 MAILHOG_VERSION=v1.0.1
 POSTGRES_VERSION=14.5-alpine
 
+## Configuration ##
+# By default the zeebe api is public, when setting this to `identity` a valid zeebe client token is required
+ZEEBE_AUTHENTICATION_MODE=none
+ZEEBE_CLIENT_ID=zeebe
+ZEEBE_CLIENT_SECRET=zecret

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ In addition to the local environment setup with docker-compose, you can download
 
 Feedback and updates are welcome!
 
+## Securing the Zeebe API
+
+By default the Zeebe GRPC API is publicly accessible without requiring any client credentials for development purposes.
+
+You can however enable authentication of GRPC requests in Zeebe by setting the environment variable `ZEEBE_AUTHENTICATION_MODE` to `identity`, e.g. via running:
+```
+ZEEBE_AUTHENTICATION_MODE=identity docker-compose up -d
+```
+or by modifying the default value in the [`.env`](.env) file.
+
 ## Connectors
 
 Both docker-compose files contain our [out-of-the-box Connectors](https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/).
@@ -141,8 +151,18 @@ $ docker-compose -f docker-compose.yaml -f docker-compose-web-modeler-beta.yaml 
 Now you can access Web Modeler Self-Managed and log in with the user `demo` and password `demo` at [http://localhost:8070](http://localhost:8070).
 
 Once you are ready to deploy or execute processes use these settings to deploy to the local Zeebe instance:
-* Authentication: None
+* Authentication: `None`
 * URL: `zeebe:26500`
+
+### Web Modeler with Zeebe request authentication
+
+If you enabled authentication for GRPC requests on Zeebe you need to provide client credentials when deploying and executing processes:
+* Authentication: `Oauth`
+* URL: `zeebe:26500`
+* Client ID: `zeebe`
+* Client secret: `zecret`
+* OAuth URL: `http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token`
+* Audience: `zeebe-api`
 
 ### Emails
 The setup includes [MailHog](https://github.com/mailhog/MailHog) as a test SMTP server. It captures all emails sent by Web Modeler, but does not forward them to the actual recipients. 

--- a/docker-compose-web-modeler-beta.yaml
+++ b/docker-compose-web-modeler-beta.yaml
@@ -108,7 +108,6 @@ services:
       RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
     networks:
     - modeler
-    - identity-network
     - camunda-platform
 
   modeler-webapp:
@@ -146,10 +145,8 @@ services:
       IDENTITY_BASE_URL: http://identity:8084/
     networks:
       - modeler
-      - identity-network
       - camunda-platform
 
 networks:
   camunda-platform:
-  identity-network:
   modeler:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,9 @@ services:
       - "26500:26500"
       - "9600:9600"
     environment: # https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/environment-variables/
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE=${ZEEBE_AUTHENTICATION_MODE}
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL=http://keycloak:8080/auth/realms/camunda-platform
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE=zeebe-api
       - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
       - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL=http://elasticsearch:9200
       - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE=1
@@ -32,6 +35,7 @@ services:
       - camunda-platform
     depends_on:
       - elasticsearch
+      - identity
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
@@ -40,6 +44,10 @@ services:
       - "8081:8080"
     environment: # https://docs.camunda.io/docs/self-managed/operate-deployment/configuration/
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
       # For more information regarding configuration with Identity see:
@@ -54,7 +62,6 @@ services:
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
     networks:
       - camunda-platform
-      - identity-network
     depends_on:
       - zeebe
       - identity
@@ -67,6 +74,10 @@ services:
       - "8082:8080"
     environment: # https://docs.camunda.io/docs/self-managed/tasklist-deployment/configuration/
       - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
       # For more information regarding configuration with Identity see:
@@ -81,7 +92,6 @@ services:
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
     networks:
       - camunda-platform
-      - identity-network
     depends_on:
       - zeebe
       - identity
@@ -95,6 +105,10 @@ services:
     environment:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
       - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL=http://keycloak:8080
       - CAMUNDA_OPERATE_CLIENT_CLIENT-ID=connectors
       - CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET=c0nn3ct0rsAr3Aw3s0me
@@ -103,7 +117,6 @@ services:
     env_file: connector-secrets.txt
     networks:
       - camunda-platform
-      - identity-network
     depends_on:
       - zeebe
       - operate
@@ -132,7 +145,6 @@ services:
     restart: on-failure
     networks:
       - camunda-platform
-      - identity-network
     depends_on:
       - identity
       - elasticsearch
@@ -153,7 +165,8 @@ services:
       KEYCLOAK_INIT_TASKLIST_ROOT_URL: http://localhost:8082
       KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
       KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8083
-      KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://localhost:8070   
+      KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://localhost:8070  
+      KEYCLOAK_INIT_ZEEBE_NAME: zeebe
       KEYCLOAK_USERS_0_USERNAME: "demo"
       KEYCLOAK_USERS_0_PASSWORD: "demo"
       KEYCLOAK_USERS_0_FIRST_NAME: "demo"
@@ -170,6 +183,12 @@ services:
       KEYCLOAK_CLIENTS_0_REDIRECT_URIS_0: /
       KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID: operate-api
       KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION: read:*
+      KEYCLOAK_CLIENTS_1_NAME: zeebe
+      KEYCLOAK_CLIENTS_1_ID: ${ZEEBE_CLIENT_ID}
+      KEYCLOAK_CLIENTS_1_SECRET: ${ZEEBE_CLIENT_SECRET}
+      KEYCLOAK_CLIENTS_1_TYPE: M2M
+      KEYCLOAK_CLIENTS_1_PERMISSIONS_0_RESOURCE_SERVER_ID: zeebe-api
+      KEYCLOAK_CLIENTS_1_PERMISSIONS_0_DEFINITION: write:*
     healthcheck:
       test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health" ]
       interval: 5s
@@ -180,6 +199,7 @@ services:
     volumes:
       - keycloak-theme:/app/keycloak-theme
     networks:
+      - camunda-platform
       - identity-network
     depends_on:
       keycloak:
@@ -224,6 +244,7 @@ services:
       retries: 5
       start_period: 30s
     networks:
+      - camunda-platform
       - identity-network
     depends_on:
       - postgres
@@ -279,6 +300,6 @@ volumes:
 
 networks:
   # Note there are two bridge networks: One for Camunda Platform and one for Identity.
-  # Operate, Tasklist, and Optimize use both
+  # Identity and Keycloak are part of both as they need to be accessible by platform components.
   camunda-platform:
   identity-network:


### PR DESCRIPTION
This adds all the required config to run the stack with an authentication secured Zeebe GRPC API.
I went for leaving it disabled by default to lower the boundary of "playing around" as otherwise clients and web modeler require the credential setup.

closes #104