### PR TITLE
docs(README): Emphasize dev options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains links to Camunda Platform 8 resources, the offical rele
 
 We recommend using [SaaS](https://camunda.com/get-started/) or [Helm/Kubernetes](https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/overview/) for development.
 
-For more information about Self-Managed, including additional [development installation options], see our [documentation](https://docs.camunda.io/docs/next/self-managed/about-self-managed/).
+For more information about Self-Managed, including additional [development installation options](https://docs.camunda.io/docs/next/self-managed/platform-deployment/overview/#development), see our [documentation](https://docs.camunda.io/docs/next/self-managed/about-self-managed/).
 
 For production setups we recommend using [Helm charts](https://docs.camunda.io/docs/self-managed/platform-deployment/kubernetes-helm/) which can be found at [helm.camunda.io](https://helm.camunda.io/).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository contains links to Camunda Platform 8 resources, the offical rele
 
 :warning: **Docker Compose is only recommended for local development.** :warning:
 
-For more information about Self-Managed, including additional development installation options, see our [documentation](https://docs.camunda.io/docs/next/self-managed/about-self-managed/).
+We recommend using [SaaS](https://camunda.com/get-started/) or [Helm/Kubernetes](https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/overview/) for development.
+
+For more information about Self-Managed, including additional [development installation options], see our [documentation](https://docs.camunda.io/docs/next/self-managed/about-self-managed/).
 
 For production setups we recommend using [Helm charts](https://docs.camunda.io/docs/self-managed/platform-deployment/kubernetes-helm/) which can be found at [helm.camunda.io](https://helm.camunda.io/).
 


### PR DESCRIPTION
Add language to encourage the first 2 development options, given we mention Docker compose (because the Docker compose file lives in this repo). 