### PR TITLE
chore(web-modeler): enable Zeebe Play

### DIFF
--- a/docker-compose-web-modeler-beta.yaml
+++ b/docker-compose-web-modeler-beta.yaml
@@ -143,6 +143,7 @@ services:
       KEYCLOAK_REALM: camunda-platform
       KEYCLOAK_JWKS_URL: http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
       IDENTITY_BASE_URL: http://identity:8084/
+      PLAY_ENABLED: "true"
     networks:
       - modeler
       - camunda-platform


### PR DESCRIPTION
Docker Compose part of https://github.com/camunda/web-modeler/issues/4284.

**Note**: The change will only become effective with the yet to-be-released 8.2 images of Web Modeler.