### PR TITLE
fix: variable is actually called GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Edit release notes with output from script
         working-directory: ./release-notes-fetcher
-        run: gh release edit --notes-file release_notes.txt -R camunda/camunda-platform $GITHUB_REF
+        run: gh release edit --notes-file release_notes.txt -R camunda/camunda-platform $GITHUB_REF_NAME
 
       - name: Create temporary directory for asset download/upload
         working-directory: ./release-notes-fetcher


### PR DESCRIPTION
that's embarrassing.

What happened here is that when we ran 
```
gh release edit ... $GITHUB_REF
```
`$GITHUB_REF` either gets populated with a full github reference (such as `refs/tags/8.3.0`) instead of `8.3.0`, or possibly an empty string because github actions is very inconsistent.  

GITHUB_REF_NAME is the proper value we should have been using, and the local shell script version already was referencing this.