### PR TITLE
feat(ci): renovate configuration for updating CAMUNDA_PLATFORM_VERSION

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,46 @@
+{
+  "extends": ["config:base"],
+  "description": "Keeps camunda-platform up to date",
+  "baseBranches": ["main", "/^stable\\/.*/"],
+  "dependencyDashboard": true,
+
+  "packageRules": [
+    {
+      "matchBaseBranches": ["/^stable\\/8.0/"],
+      "matchDepNames": ["camunda/operate"],
+      "allowedVersions": "<8.1.0",
+    },
+    {
+      "matchBaseBranches": ["/^stable\\/8.1/"],
+      "matchDepNames": ["camunda/operate"],
+      "allowedVersions": "<8.2.0",
+    },
+    {
+      "matchBaseBranches": ["/^stable\\/8.2/"],
+      "matchDepNames": ["camunda/operate"],
+      "allowedVersions": "<8.3.0",
+    },
+    {
+      "matchBaseBranches": ["/^stable\\/8.3/"],
+      "matchDepNames": ["camunda/operate"],
+      "allowedVersions": "<8.4.0",
+    },
+  ],
+
+  "regexManagers": [
+    {
+      "fileMatch": [".env"],
+      "matchStrings": ["CAMUNDA_PLATFORM_VERSION\\s*=\\s*(?<currentValue>\\S+)"],
+      // Watch camunda/operate registry even though this env variable is also used in
+      // * camunda/identity
+      // * camunda/tasklist
+      // * camunda/zeebe
+      //
+      // If one of these images does not exist yet, the expected behavior is that
+      // the PR gets submitted, but the CI build will not pass because the other
+      // images will not be available.
+      "depNameTemplate": "camunda/operate",
+      "datasourceTemplate": "docker",
+    },
+  ],
+}


### PR DESCRIPTION
I've created this [repo](https://github.com/camunda/camunda-platform-renovate-test/issues)  to test running renovate on this repository. My primary motivation is to automate the process of updating CAMUNDA_PLATFORM_VERSION whenever `camunda/operate` puts out a release.  Since this version is synchronized across zeebe, identity, operate, and tasklist, and renovate configs can only look at one datasource, I just chose camunda/operate.   

The expected workflow if  operate publishes an image but  identity does not is that the CI will fail and maintainers of this repository will rerun the Github Actions after some time has past.

Including renovate does also come with the side effect that it might recommend updates for other parts of our repository too, such as our go.mod file for the release notes script, or  the keycloak image in the docker-compose file.  I see this as a plus, but we can tune it later if it doesn't work for us.

This will also update `stable/8.x` branches with the latest patch release number.