### PR TITLE
fix(ci): renames job names

### DIFF
--- a/.github/workflows/test-default.yaml
+++ b/.github/workflows/test-default.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "**"
 jobs:
-  test_core:
+  test_docker_compose_yaml:
     uses: ./.github/workflows/template-deploy.yaml
     secrets: inherit
     with:

--- a/.github/workflows/test-modeler.yaml
+++ b/.github/workflows/test-modeler.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "**"
 jobs:
-  test_core:
+  test_modeler_yaml:
     uses: ./.github/workflows/template-deploy.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
I want to set up branch protection, and it's complicating the github settings when the job names in my github actions are all the same.  This PR changes the names to be unique