### PR TITLE
fix: operate / tasklist binaries now have bin folder with binaries (n…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
         working-directory: ./release-notes-fetcher
         run: mkdir -p tmp
 
+      # Operate and tasklist binaries are uploaded to zeebes repo
       - name: Download Zeebe resources
         working-directory: ./release-notes-fetcher/tmp
         run: >
@@ -68,20 +69,14 @@ jobs:
           -p "camunda-zeebe-$GITHUB_REF_NAME.tar.gz.sha1sum"
           -p "camunda-zeebe-$GITHUB_REF_NAME.zip"
           -p "camunda-zeebe-$GITHUB_REF_NAME.zip.sha1sum"
-
-
-      # Operate repo owners do not create github releases, so we just download the tags zip/tarball
-      - name: Download Operate resources
-        working-directory: ./release-notes-fetcher/tmp
-        run: |-
-          gh api /repos/camunda/operate/tarball/$GITHUB_REF_NAME > camunda-operate-$GITHUB_REF_NAME.tar.gz
-          gh api /repos/camunda/operate/zipball/$GITHUB_REF_NAME > camunda-operate-$GITHUB_REF_NAME.zip
-
-      - name: Download Tasklist resources
-        working-directory: ./release-notes-fetcher/tmp
-        run: |-
-          gh api /repos/camunda/tasklist/tarball/$GITHUB_REF_NAME > camunda-tasklist-$GITHUB_REF_NAME.tar.gz
-          gh api /repos/camunda/tasklist/zipball/$GITHUB_REF_NAME > camunda-tasklist-$GITHUB_REF_NAME.zip
+          -p "camunda-operate-$GITHUB_REF_NAME.zip"
+          -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum"
+          -p "camunda-operate-$GITHUB_REF_NAME.tar.gz"
+          -p "camunda-operate-$GITHUB_REF_NAME.tar.gz.sha1sum"
+          -p "camunda-tasklist-$GITHUB_REF_NAME.zip"
+          -p "camunda-tasklist-$GITHUB_REF_NAME.zip.sha1sum"
+          -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz"
+          -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
       - name: Login to Camunda Cloud
         working-directory: ./release-notes-fetcher

--- a/release-notes-fetcher/release.sh
+++ b/release-notes-fetcher/release.sh
@@ -26,12 +26,15 @@ gh release \
   -p "camunda-zeebe-$GITHUB_REF_NAME.tar.gz" \
   -p "camunda-zeebe-$GITHUB_REF_NAME.tar.gz.sha1sum" \
   -p "camunda-zeebe-$GITHUB_REF_NAME.zip" \
-  -p "camunda-zeebe-$GITHUB_REF_NAME.zip.sha1sum"
-
-gh api /repos/camunda/operate/tarball/$GITHUB_REF_NAME > camunda-operate-$GITHUB_REF_NAME.tar.gz
-gh api /repos/camunda/operate/zipball/$GITHUB_REF_NAME > camunda-operate-$GITHUB_REF_NAME.zip
-gh api /repos/camunda/tasklist/tarball/$GITHUB_REF_NAME > camunda-tasklist-$GITHUB_REF_NAME.tar.gz
-gh api /repos/camunda/tasklist/zipball/$GITHUB_REF_NAME > camunda-tasklist-$GITHUB_REF_NAME.zip
+  -p "camunda-zeebe-$GITHUB_REF_NAME.zip.sha1sum" \
+  -p "camunda-operate-$GITHUB_REF_NAME.zip" \
+  -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum" \
+  -p "camunda-operate-$GITHUB_REF_NAME.tar.gz" \
+  -p "camunda-operate-$GITHUB_REF_NAME.tar.gz.sha1sum" \
+  -p "camunda-tasklist-$GITHUB_REF_NAME.zip" \
+  -p "camunda-tasklist-$GITHUB_REF_NAME.zip.sha1sum" \
+  -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz" \
+  -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
 gh release \
   download "$GITHUB_REF_NAME" \


### PR DESCRIPTION
…ot just source code)

Previously, operate and tasklist uploaded .tar.gz and .zip files that did not contain the expected files inside according to our documentation. Our documentation specifies that there is a bin folder and built binaries constructed inside, whereas we only had source code in those files.

This fetches the .tar.gz / .zip files from the proper spot (zeebe repo for now, which may change later).