### PR TITLE
fix: adds unit test for release script to simplify renovate updates

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -37,9 +37,10 @@ jobs:
 
       - name: Run release notes script
         working-directory: ./release-notes-fetcher
-        run: set -o pipefail; ./release-notes-fetcher | tee release_notes.txt
+        # hard-codes 8.2.3 since GITHUB_REF_NAME points to the branch name usually
+        # and we just want to see if a valid version can fetch notes
+        run: set -o pipefail; GITHUB_REF_NAME=8.2.3 ./release-notes-fetcher | tee release_notes.txt
         env:
           GITHUB_CAMUNDA_ACCESS_TOKEN: ${{ steps.generate-camunda-github-token.outputs.token }}
           GITHUB_CAMUNDA_CLOUD_ACCESS_TOKEN: ${{ steps.generate-camunda-cloud-github-token.outputs.token }}
-          GITHUB_REF_NAME: 8.2.3
 

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,45 @@
+name: "Test release notes script"
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  release_script:
+    runs-on: ubuntu-latest
+    name: Build release script
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+      
+      - name: Build
+        working-directory: ./release-notes-fetcher
+        run: go build
+
+      - name: Generate token for Camunda GitHub org
+        id: generate-camunda-github-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Generate token for Camunda Cloud GitHub org
+        id: generate-camunda-cloud-github-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          repository: camunda-cloud/identity
+
+      - name: Run release notes script
+        working-directory: ./release-notes-fetcher
+        run: set -o pipefail; ./release-notes-fetcher | tee release_notes.txt
+        env:
+          GITHUB_CAMUNDA_ACCESS_TOKEN: ${{ steps.generate-camunda-github-token.outputs.token }}
+          GITHUB_CAMUNDA_CLOUD_ACCESS_TOKEN: ${{ steps.generate-camunda-cloud-github-token.outputs.token }}
+          GITHUB_REF_NAME: 8.2.3
+


### PR DESCRIPTION
We get a lot of renovate update changes relating to parts of the release notes script. I added a github actions workflow that will run the release notes script without updating anything just to test if a new version of a dependency breaks the script.