### PR TITLE
Expose port so that modeler-restapi can connect to modeler-db

### DIFF
--- a/docker-compose-web-modeler.yaml
+++ b/docker-compose-web-modeler.yaml
@@ -12,6 +12,8 @@ services:
   modeler-db:
     container_name: modeler-db
     image: postgres:${POSTGRES_VERSION}
+    ports:
+      - "5432:5432"
     healthcheck:
       test: pg_isready -d modeler-db -U modeler-db-user
       interval: 5s


### PR DESCRIPTION
I noticed the modeler-restapi container was struggling to connect to the database. I added this port mapping and seems to be happy now :-)