### PR TITLE
Fix aarch64 keycloak

### DIFF
--- a/.keycloak/Dockerfile
+++ b/.keycloak/Dockerfile
@@ -37,7 +37,7 @@ RUN ln -s /opt/keycloak /opt/bitnami/keycloak
 RUN sed -i 's/export JAVA_HOME=\"\/opt\/bitnami\/java\"//' /opt/bitnami/scripts/keycloak-env.sh
 
 RUN microdnf update -y && \
-    microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en hostname tar gzip && microdnf clean all && rm -rf /var/cache/yum/* && \
+    microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en hostname tar gzip tzdata-java-2023c && microdnf clean all && rm -rf /var/cache/yum/* && \
     echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 


### PR DESCRIPTION
When building your own keycloak docker image on aarch64 architectures (commonly on m1 macs), running recently will throw an error:
```
ERROR: Failed to run 'build' command.
ERROR: Failed to update server configuration.
ERROR: Could not initialize class sun.util.calendar.ZoneInfoFile
For more details run the same command passing the '--verbose' option. Also you can use '--help' to see the details about the usage of the particular command.
```

While debugging, I noticed there was a missing symlink, and that the file that the symlink pointed to belongs to a package not installed on our docker image.  This PR adds that package, and provides that file.

To debug this, I created an aarch64 VM, since I do not own an M1 Mac, and then I ran 
```
DOCKER_BUILDKIT=0 docker build -t bitnami/keycloak:19.0.3 -f .keycloak/Dockerfile  
```

And then

```
docker compose up -d
```

Before the patch, you will see the error I showed above. After this patch, it should start up normally.