### PR TITLE
Add headline to basic components

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To tear down the whole environment run the following command:
 docker compose down -v
 ```
 
+### Using the basic components
+
 If Optimize, Identity, and Keycloak are not needed you can use the [docker-compose-core.yaml](docker-compose-core.yaml) instead which does not include these components:
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To tear down the whole environment run the following command:
 docker compose down -v
 ```
 
+Zeebe, Operate, Tasklist, along with Optimize require a separate network from Identity as you'll see in the docker-compose file.
+
 ### Using the basic components
 
 If Optimize, Identity, and Keycloak are not needed you can use the [docker-compose-core.yaml](docker-compose-core.yaml) instead which does not include these components:
@@ -75,7 +77,7 @@ If Optimize, Identity, and Keycloak are not needed you can use the [docker-compo
 docker compose -f docker-compose-core.yaml up -d
 ```
 
-Zeebe, Operate, Tasklist, along with Optimize require a separate network from Identity as you'll see in the docker-compose file.
+### Deploying BPMN diagrams
 
 In addition to the local environment setup with docker compose, you can download the [Camunda Desktop Modeler](https://camunda.com/download/modeler/) to locally model BPMN diagrams for execution and directly deploy them to your local environment.
 As an enterprise customer, you can [use Web Modeler](#web-modeler-self-managed).


### PR DESCRIPTION
For a better linking in other docs, introduce a headline and an anchor to the docker-compose-core description.