### PR TITLE
Stop renovate from upgrading go-github

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,10 @@
       "enabled": false,
     },
     {
+      "matchDepNames": ["github.com/google/go-github/v54"],
+      "enabled": false,
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
       "enabled": false,
     },
     {
-      "matchDepNames": ["github.com/google/go-github/v54"],
+      "matchDepNames": ["github.com/google/go-github/*"],
       "enabled": false,
     },
     {


### PR DESCRIPTION
These dependency upgrades for go-github are excessive, and violates typical versioning schemes, so renovate often outputs a PR that doesn't work.  Furthermore, theres no need to update this dependency until it stops working.