### PR TITLE
chore: get release notes from operate release by tag instead of changelog

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -37,9 +37,9 @@ jobs:
 
       - name: Run release notes script
         working-directory: ./release-notes-fetcher
-        # hard-codes 8.2.3 since GITHUB_REF_NAME points to the branch name usually
+        # hard-codes 8.3.1 since GITHUB_REF_NAME points to the branch name usually
         # and we just want to see if a valid version can fetch notes
-        run: set -o pipefail; GITHUB_REF_NAME=8.2.3 ./release-notes-fetcher | tee release_notes.txt
+        run: set -o pipefail; GITHUB_REF_NAME=8.3.1 ./release-notes-fetcher | tee release_notes.txt
         env:
           GITHUB_CAMUNDA_ACCESS_TOKEN: ${{ steps.generate-camunda-github-token.outputs.token }}
           GITHUB_CAMUNDA_CLOUD_ACCESS_TOKEN: ${{ steps.generate-camunda-cloud-github-token.outputs.token }}

--- a/release-notes-fetcher/fetch.go
+++ b/release-notes-fetcher/fetch.go
@@ -110,10 +110,10 @@ func main() {
 		githubRef,
 	)
 
-	operateReleaseNotesContents := GetChangelogReleaseContents(
+	operateReleaseNotesContents := GetLatestReleaseContents(
 		ctx,
+		RepoOwner,
 		OperateRepoName,
-		"CHANGELOG.md",
 		camundaRepoService,
 		githubRef,
 	)


### PR DESCRIPTION
This PR changes the way camunda-platform collects release notes from Operate, because in the future releases Operate will be pushing release notes to the individual releases (https://github.com/camunda/operate/releases) in the release body as seen in the screenshot below.


![Screenshot 2023-10-24 at 17 44 12](https://github.com/camunda/camunda-platform/assets/45518829/a29fcd0f-2010-4b85-8061-5078cf53bd8a)