### PR TITLE
fix: disables all renovate go updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
       "enabled": false,
     },
     {
-      "matchDepNames": ["github.com/google/go-github/**"],
+      "matchDatasources": ["go"],
       "enabled": false,
     },
     {


### PR DESCRIPTION
I'm getting increasingly annoyed with the dependency updates for just a silly release notes script.  There's no risk for this script becoming out-of-date.