### PR TITLE
refactor: use wget for Tasklist healthcheck

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -75,7 +75,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,7 +120,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
Readiness probe for Tasklist container always fails.
Since we have changed the base image of Tasklist to Alpine and `curl` is not installed by default in Alpine.