### PR TITLE
chore(deps): upgrade connectors version to 0.23.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=camunda/connectors-bundle
-CAMUNDA_CONNECTORS_VERSION=0.16.1
+CAMUNDA_CONNECTORS_VERSION=0.23.0
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=3.9.5
 CAMUNDA_PLATFORM_VERSION=8.1.21


### PR DESCRIPTION
Noticed that the `connectors` version for platform 8.1 was outdated. Chat here: [Camunda Slack](https://camunda.slack.com/archives/C02JLRNQQ05/p1704737247056469). Upgrade connectors to version 0.23.0.