### PR TITLE
Restart containers unless stopped

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -26,7 +26,7 @@ services:
       - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
       - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: [ "CMD-SHELL", "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1" ]
       interval: 30s
@@ -129,7 +129,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
       interval: 30s


### PR DESCRIPTION
Change the restart policy of container zeebe and elasticsearch from always to unless-stopped.

With this change, the user can control when the cluster should be started and stopped explicitly. Cluster stop will survive a restart of Docker or the host computer.

For a development environment, where I have to take care of the resources, this should be sufficient.

If this pull request gets accepted, we can discuss if it is useful for the full docker-compose.yaml as well and if it should be mentioned in the readme.