### PR TITLE
chore(connectors): switch to identity SDK config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -145,7 +145,11 @@ services:
     environment:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
       - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
       - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
       - CAMUNDA_IDENTITY_BASE_URL=http://identity:8084
       - CAMUNDA_IDENTITY_ISSUER=http://${HOST}:18080/auth/realms/camunda-platform

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -145,16 +145,15 @@ services:
     environment:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
       - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
-      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
-      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
       - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
-      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
-      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
-      - CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL=http://keycloak:8080
-      - CAMUNDA_OPERATE_CLIENT_CLIENT-ID=connectors
-      - CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-      - CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM=camunda-platform
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
+      - CAMUNDA_IDENTITY_BASE_URL=http://identity:8084
+      - CAMUNDA_IDENTITY_ISSUER=http://${HOST}:18080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_CLIENT_ID=connectors
+      - CAMUNDA_IDENTITY_CLIENT_SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_IDENTITY_TYPE=KEYCLOAK
+      - CAMUNDA_IDENTITY_AUDIENCE=connectors
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     env_file: connector-secrets.txt


### PR DESCRIPTION
Switch Connectors to the new authentication mechanism via Identity SDK.

`docker-compose-core` is not affected.

Depends on: https://github.com/camunda/connectors/pull/1847

Related to: https://github.com/camunda/connectors/issues/1638