### PR TITLE
Update elasticsearch health check in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -332,7 +332,7 @@ services:
         hard: -1
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
+      test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q yellow" ]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Unless the default shard and replica setting are not changed the check has to look for yellow state.

This is necessary because the health check seem to be ignored on initial creation. But after restarted the check is reporting unhealthy which prevents the setup to start.

This is a patch related to #471