### PR TITLE
fix(connectors): use correct audience for operate auth

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -151,7 +151,6 @@ services:
       - ZEEBE_TOKEN_AUDIENCE=zeebe-api
       - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
-      - CAMUNDA_IDENTITY_BASE_URL=http://identity:8084
       - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_CLIENT_ID=connectors
       - CAMUNDA_IDENTITY_CLIENT_SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,7 +152,6 @@ services:
       - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
       - CAMUNDA_IDENTITY_BASE_URL=http://identity:8084
-      - CAMUNDA_IDENTITY_ISSUER=http://${HOST}:18080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_CLIENT_ID=connectors
       - CAMUNDA_IDENTITY_CLIENT_SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,7 +157,7 @@ services:
       - CAMUNDA_IDENTITY_CLIENT_ID=connectors
       - CAMUNDA_IDENTITY_CLIENT_SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
       - CAMUNDA_IDENTITY_TYPE=KEYCLOAK
-      - CAMUNDA_IDENTITY_AUDIENCE=connectors
+      - CAMUNDA_IDENTITY_AUDIENCE=operate-api
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     env_file: connector-secrets.txt


### PR DESCRIPTION
Connectors should use the Operate audience to authenticate with Operate.