### PR TITLE
Added volume to modeler-db to preserver diagrams

### DIFF
--- a/docker-compose-web-modeler.yaml
+++ b/docker-compose-web-modeler.yaml
@@ -23,6 +23,8 @@ services:
       POSTGRES_PASSWORD: modeler-db-password
     networks:
       - modeler
+    volumes:
+      - postgres-web:/var/lib/postgresql/data
 
   modeler-websockets:
     container_name: modeler-websockets
@@ -137,3 +139,6 @@ services:
 networks:
   camunda-platform:
   modeler:
+
+volumes:
+  postgres-web:


### PR DESCRIPTION
Related support ticket: https://jira.camunda.com/plugins/servlet/samlsso?redirectTo=%2Fbrowse%2FSUPPORT-20531

I added a volume to the modeler-db in order to preserve the diagrams that are created.