### PR TITLE
fix: get Operate artifacts from monorepo starting with 8.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,8 +91,8 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release
-          download "operate-$GITHUB_REF_NAME"
-          -R camunda/zeebe
+          download "$GITHUB_REF_NAME"
+          -R camunda/operate
           -p "camunda-operate-$GITHUB_REF_NAME.zip"
           -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum"
           -p "camunda-operate-$GITHUB_REF_NAME.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,20 @@ jobs:
           -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz"
           -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
+      - name: Download Operate resources from monorepo
+        if: ${{ startsWith(env.GITHUB_REF_NAME, '8.5') }}
+        working-directory: ./release-notes-fetcher/tmp
+        run: >
+          gh release
+          download "operate-$GITHUB_REF_NAME"
+          -R camunda/zeebe
+          -p "camunda-operate-$GITHUB_REF_NAME.zip"
+          -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum"
+          -p "camunda-operate-$GITHUB_REF_NAME.tar.gz"
+          -p "camunda-operate-$GITHUB_REF_NAME.tar.gz.sha1sum"
+
       - name: Download Operate resources
+        if: ${{ !startsWith(env.GITHUB_REF_NAME, '8.5') }}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,8 +78,8 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release
-          download "$GITHUB_REF_NAME"
-          -R camunda/operate
+          download "operate-$GITHUB_REF_NAME"
+          -R camunda/zeebe
           -p "camunda-operate-$GITHUB_REF_NAME.zip"
           -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum"
           -p "camunda-operate-$GITHUB_REF_NAME.tar.gz"


### PR DESCRIPTION
This should probably get backported to `stable/8.5` branch.