### PR TITLE
chore: add compose profiles for web modeler

### DIFF
--- a/docker-compose/camunda-8.6/.env
+++ b/docker-compose/camunda-8.6/.env
@@ -1,0 +1,32 @@
+## Image versions ##
+# renovate: datasource=docker depName=camunda/connectors-bundle
+CAMUNDA_CONNECTORS_VERSION=8.5.3
+CAMUNDA_PLATFORM_VERSION=8.5.0
+# renovate: datasource=docker depName=camunda/optimize
+CAMUNDA_OPTIMIZE_VERSION=8.5.1
+# renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
+CAMUNDA_WEB_MODELER_VERSION=8.5.1
+# renovate: datasource=docker depName=elasticsearch
+ELASTIC_VERSION=8.13.4
+KEYCLOAK_SERVER_VERSION=21.1.2
+MAILPIT_VERSION=v1.9.9
+POSTGRES_VERSION=14.5-alpine
+HOST=localhost
+
+## Configuration ##
+# By default the zeebe api is public, when setting this to `identity` a valid zeebe client token is required
+ZEEBE_AUTHENTICATION_MODE=none
+ZEEBE_CLIENT_ID=zeebe
+ZEEBE_CLIENT_SECRET=zecret
+
+# Set to 'true' to enable resource based authorizations for users and groups
+# This can be used to limit access for users or groups to view/update specific
+# processes and decisions in Operate and Tasklist
+RESOURCE_AUTHORIZATIONS_ENABLED=false
+
+# Set to 'true' to enable multi-tenancy across all components
+# This requires use of identity for authentication
+#
+#  ZEEBE_AUTHENTICATION_MODE=identity
+#
+MULTI_TENANCY_ENABLED=false

--- a/docker-compose/camunda-8.6/README.md
+++ b/docker-compose/camunda-8.6/README.md
@@ -1,0 +1,255 @@
+# Camunda Platform 8
+
+This repository contains links to Camunda Platform 8 resources, the official release artifacts (binaries), and supporting config files for running Docker Compose as a local development option. 
+
+:warning: **Docker Compose is only recommended for local development.** :warning:
+
+We recommend using [SaaS](https://camunda.com/get-started/) or [Helm/Kubernetes](https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/overview/) for development.
+
+For more information about Self-Managed, including additional [development installation options](https://docs.camunda.io/docs/next/self-managed/platform-deployment/overview/#development), see our [documentation](https://docs.camunda.io/docs/next/self-managed/about-self-managed/).
+
+For production setups we recommend using [Helm charts](https://docs.camunda.io/docs/self-managed/platform-deployment/kubernetes-helm/) which can be found at [helm.camunda.io](https://helm.camunda.io/).
+
+## Links to additional Camunda Platform 8 repos and assets
+
+- [Documentation](https://docs.camunda.io)
+- [Camunda Platform SaaS](https://camunda.io)
+- [Getting Started Guide](https://github.com/camunda/camunda-platform-get-started)
+- [Releases](https://github.com/camunda/camunda-platform/releases)
+- [Helm Charts](https://helm.camunda.io/)
+- [Zeebe Workflow Engine](https://github.com/camunda/zeebe)
+- [Contact](https://docs.camunda.io/contact/)
+
+## Using docker compose
+
+> :information_source: The docker-compose file in this repository uses the latest [compose specification](https://docs.docker.com/compose/compose-file/), which was introduced with docker compose version 1.27.0+. Please make sure to use an up-to-date docker compose version.
+
+> :information_source: Docker 20.10.16+ is required.
+
+To spin up a complete Camunda Platform 8 Self-Managed environment locally the [docker-compose.yaml](docker-compose.yaml) file in this repository can be used.
+
+The full environment contains these components:
+- Zeebe
+- Operate
+- Tasklist
+- Connectors
+- Optimize
+- Identity
+- Elasticsearch
+- Keycloak
+- PostgreSQL
+
+> :information_source: Web Modeler is not included by default. Please follow [the instructions below](#web-modeler-self-managed) to install it.
+
+Clone this repo and issue the following command to start your environment:
+
+```
+docker compose up -d
+```
+
+Wait a few minutes for the environment to start up and settle down. Monitor the logs, especially the Keycloak container log, to ensure the components have started.
+
+Now you can navigate to the different web apps and log in with the user `demo` and password `demo`:
+- Operate: [http://localhost:8081](http://localhost:8081)
+- Tasklist: [http://localhost:8082](http://localhost:8082)
+- Optimize: [http://localhost:8083](http://localhost:8083)
+- Identity: [http://localhost:8084](http://localhost:8084)
+- Elasticsearch: [http://localhost:9200](http://localhost:9200)
+
+Keycloak is used to manage users. Here you can log in with the user `admin` and password `admin`
+- Keycloak: [http://localhost:18080/auth/](http://localhost:18080/auth/)
+
+The workflow engine Zeebe is available using gRPC at `localhost:26500`.
+
+To tear down the whole environment run the following command:
+
+```
+docker compose down -v
+```
+
+Zeebe, Operate, Tasklist, along with Optimize require a separate network from Identity as you'll see in the docker-compose file.
+
+### Using the basic components
+
+If Optimize, Identity, and Keycloak are not needed you can use the [docker-compose-core.yaml](docker-compose-core.yaml) instead which does not include these components:
+
+```
+docker compose -f docker-compose-core.yaml up -d
+```
+
+### Deploying BPMN diagrams
+
+In addition to the local environment setup with docker compose, use the [Camunda Desktop Modeler](#desktop-modeler) to locally model BPMN diagrams for execution and directly deploy them to your local environment.
+As an enterprise customer, you can [use Web Modeler](#web-modeler-self-managed).
+
+Feedback and updates are welcome!
+
+## Securing the Zeebe API
+
+By default, the Zeebe GRPC API is publicly accessible without requiring any client credentials for development purposes.
+
+You can however enable authentication of GRPC requests in Zeebe by setting the environment variable `ZEEBE_AUTHENTICATION_MODE` to `identity`, e.g. via running:
+```
+ZEEBE_AUTHENTICATION_MODE=identity docker compose up -d
+```
+or by modifying the default value in the [`.env`](.env) file.
+
+## Connectors
+
+Both docker-compose files contain our [out-of-the-box Connectors](https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/).
+
+Refer to the [Connector installation guide](https://docs.camunda.io/docs/self-managed/connectors-deployment/install-and-start/) for details on how to provide the related Connector templates for modeling.
+
+To inject secrets into the Connector runtime they can be added to the
+[`connector-secrets.txt`](connector-secrets.txt) file inside the repository in the format `NAME=VALUE`
+per line. The secrets will then be available in the Connector runtime with the
+format `secrets.NAME`.
+
+To add custom Connectors either create a new docker image bundling them as
+described [here](https://github.com/camunda/connectors-bundle/tree/main/runtime).
+
+Alternatively, you can mount new Connector JARs as volumes into the `/opt/app` folder by adding this to the docker-compose file. Keep in mind that the Connector JARs need to bring along all necessary dependencies inside the JAR.
+
+## Kibana
+
+A `kibana` profile is available in the provided docker compose files to support inspection and exploration of the Camunda Platform 8 data in Elasticsearch.
+It can be enabled by adding `--profile kibana` to your docker compose command.
+In addition to the other components, this profile spins up [Kibana](https://www.elastic.co/kibana/).
+Kibana can be used to explore the records exported by Zeebe into Elasticsearch, or to discover the data in Elasticsearch used by the other components (e.g. Operate).
+
+You can navigate to the Kibana web app and start exploring the data without login credentials:
+
+- Kibana: [http://localhost:5601](http://localhost:5601)
+
+> **Note**
+> You need to configure the index patterns in Kibana before you can explore the data.
+> - Go to `Management > Stack Management > Kibana > Index Patterns`.
+> - Create a new index pattern. For example, `zeebe-record-*` matches the exported records.
+>   - If you don't see any indexes then make sure to export some data first (e.g. deploy a process). The indexes of the records are created when the first record of this type is exported.
+> - Go to `Analytics > Discover` and select the index pattern.
+
+## Desktop Modeler
+
+> :information_source: The Desktop Modeler is [open source, free to use](https://github.com/camunda/camunda-modeler).
+
+[Download the Desktop Modeler](https://camunda.com/download/modeler/) and start modeling BPMN, DMN and Camunda Forms on your local machine.
+
+### Deploy or execute a process
+
+#### Without authentication
+Once you are ready to deploy or execute processes use these settings to deploy to the local Zeebe instance:
+* Authentication: `None`
+* URL: `http://localhost:26500`
+
+#### With Zeebe request authentication
+If you enabled authentication for GRPC requests on Zeebe you need to provide client credentials when deploying and executing processes:
+* Authentication: `OAuth`
+* URL: `http://localhost:26500`
+* Client ID: `zeebe`
+* Client secret: `zecret`
+* OAuth URL: `http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token`
+* Audience: `zeebe-api`
+
+## Web Modeler Self-Managed
+
+> :information_source: Web Modeler Self-Managed is available to Camunda enterprise customers only.
+
+The Docker images for Web Modeler are available in a private registry. Enterprise customers either already have credentials to this registry, or they can request access to this registry through their CSM contact at Camunda.
+
+To run Camunda Platform with Web Modeler Self-Managed clone this repo and issue the following commands:
+
+```
+$ docker login registry.camunda.cloud
+Username: your_username
+Password: ******
+Login Succeeded
+$ docker compose --profile web-modeler up -d
+```
+
+To tear down the whole environment run the following command
+
+```
+$ docker compose --profile web-modeler down -v
+```
+
+If you want to delete everything (including any data you created).
+Alternatively, if you want to keep the data run:
+
+```
+$ docker compose --profile web-modeler down
+```
+
+### Login
+You can access Web Modeler Self-Managed and log in with the user `demo` and password `demo` at [http://localhost:8070](http://localhost:8070).
+
+### Deploy or execute a process
+
+#### Without authentication
+Once you are ready to deploy or execute processes use these settings to deploy to the local Zeebe instance:
+* Authentication: `None`
+* URL: `http://zeebe:26500`
+
+#### With Zeebe request authentication
+If you enabled authentication for GRPC requests on Zeebe you need to provide client credentials when deploying and executing processes:
+* Authentication: `OAuth`
+* URL: `http://zeebe:26500`
+* Client ID: `zeebe`
+* Client secret: `zecret`
+* OAuth URL: `http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token`
+* Audience: `zeebe-api`
+
+### Emails
+The setup includes [Mailpit](https://github.com/axllent/mailpit) as a test SMTP server. It captures all emails sent by Web Modeler, but does not forward them to the actual recipients. 
+
+You can access emails in Mailpit's Web UI at [http://localhost:8075](http://localhost:8075).
+
+## Troubleshooting
+
+### Submitting Issues
+When submitting an issue on this repository, please make sure your issue is related to the docker compose deployment
+method of the Camunda Platform. All questions regarding to functionality of the web applications should be instead
+posted on the [Camunda Forum](https://forum.camunda.io/). This is the best way for users to query for existing answers
+that others have already encountered. We also have a category on that forum specifically for [Deployment Related Topics](https://forum.camunda.io/c/camunda-platform-8-topics/deploying-camunda-platform-8/33).
+
+### Running on arm64 based hardware
+When using arm64-based hardware like a M1 or M2 Mac the Keycloak container might not start because Bitnami only
+provides amd64-based images for versions <  22. You can build and tag an arm-based
+image locally using the following command. After building and tagging the image you can start the environment as
+described in [Using docker-compose](#using-docker-compose).
+
+```
+$ DOCKER_BUILDKIT=0 docker build -t bitnami/keycloak:19.0.3 "https://github.com/camunda/camunda-platform.git#8.2.15:.keycloak/"
+```
+
+## Resource based authorizations
+
+You can control access to specific processes and decision tables in Operate and Tasklist with [resource based authorization](https://docs.camunda.io/docs/self-managed/concepts/access-control/resource-authorizations/).
+
+This feature is disabled by default and can be enabled by setting 
+`RESOURCE_AUTHORIZATIONS_ENABLED` to `true`, either via the [`.env`](.env) file or through the command line:
+
+```
+RESOURCE_AUTHORIZATIONS_ENABLED=true docker compose up -d
+```
+
+## Multi-Tenancy
+
+You can use [multi-tenancy](https://docs.camunda.io/docs/self-managed/concepts/multi-tenancy/) to achieve tenant-based isolation.
+
+This feature is disabled by default and can be enabled by setting
+`MULTI_TENANCY_ENABLED` to `true`, either via the [`.env`](.env) file or through the command line:
+
+```
+ZEEBE_AUTHENICATION_MODE=identity MULTI_TENANCY_ENABLED=true docker compose up -d
+```
+
+As seen above the feature also requires you to use `identity` as an authentication provider.
+
+Ensure you [setup tenants in identity](https://docs.camunda.io/docs/self-managed/identity/user-guide/tenants/managing-tenants/) after you started the platform.
+
+## Camunda Platform 7
+
+Looking for information on Camunda Platform 7? Check out the links below:
+
+- [Documentation](https://docs.camunda.org/)
+- [GitHub](https://github.com/camunda/camunda-bpm-platform)

--- a/docker-compose/camunda-8.6/connector-secrets.txt
+++ b/docker-compose/camunda-8.6/connector-secrets.txt
@@ -1,0 +1,2 @@
+# add secrets per line in the format NAME=VALUE
+# WARNING: ensure not to commit changes to this file

--- a/docker-compose/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/camunda-8.6/docker-compose-core.yaml
@@ -1,0 +1,165 @@
+# While the Docker images themselves are supported for production usage,
+# this docker-compose.yaml is designed to be used by developers to run
+# an environment locally. It is not designed to be used in production.
+# We recommend to use Kubernetes in production with our Helm Charts:
+# https://docs.camunda.io/docs/self-managed/platform-deployment/kubernetes-helm/
+# For local development, we recommend using KIND instead of `docker-compose`:
+# https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/
+
+# This is a lightweight configuration with Zeebe, Operate, Tasklist, and Elasticsearch
+# See docker-compose.yml for a configuration that also includes Optimize, Identity, and Keycloak.
+
+services:
+
+  zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
+    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    container_name: zeebe
+    ports:
+      - "26500:26500"
+      - "9600:9600"
+      - "8088:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/environment-variables/
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL=http://elasticsearch:9200
+      # default is 1000, see here: https://github.com/camunda/zeebe/blob/main/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java#L259
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE=1
+      # allow running with low disk space
+      - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
+      - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
+      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1" ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - zeebe:/usr/local/zeebe/data
+    networks:
+      - camunda-platform
+    depends_on:
+      - elasticsearch
+
+  operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
+    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    container_name: operate
+    ports:
+      - "8081:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/operate-deployment/configuration/
+      - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+      - elasticsearch
+
+  tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
+    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    container_name: tasklist
+    ports:
+      - "8082:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/tasklist-deployment/configuration/
+      - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe:8080
+      - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+      - elasticsearch
+
+  connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
+    container_name: connectors
+    ports:
+      - "8085:8080"
+    environment:
+      - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
+      - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
+      - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
+      - CAMUNDA_OPERATE_CLIENT_USERNAME=demo
+      - CAMUNDA_OPERATE_CLIENT_PASSWORD=demo
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    env_file: connector-secrets.txt
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+      - operate
+
+  elasticsearch: # https://hub.docker.com/_/elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+    container_name: elasticsearch
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      # allow running with low disk space
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    networks:
+      - camunda-platform
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
+    container_name: kibana
+    ports:
+      - 5601:5601
+    volumes:
+      - kibana:/usr/share/kibana/data
+    networks:
+      - camunda-platform
+    depends_on:
+      - elasticsearch
+    profiles:
+      - kibana
+
+volumes:
+  zeebe:
+  elastic:
+  kibana:
+
+networks:
+  camunda-platform:

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -1,0 +1,522 @@
+# While the Docker images themselves are supported for production usage,
+# this docker-compose.yaml is designed to be used by developers to run
+# an environment locally. It is not designed to be used in production.
+# We recommend to use Kubernetes in production with our Helm Charts:
+# https://docs.camunda.io/docs/self-managed/platform-deployment/kubernetes-helm/
+# For local development, we recommend using KIND instead of `docker-compose`:
+# https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/
+
+# This is a full configuration with Zeebe, Operate, Tasklist, Optimize, Identity, Keycloak, Elasticsearch and optional Web Modeler.
+# See docker-compose-core.yml for a lightweight configuration that does not include Optimize, Identity, and Keycloak.
+
+services:
+
+  zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
+    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    container_name: zeebe
+    ports:
+      - "26500:26500"
+      - "9600:9600"
+      - "8088:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/environment-variables/
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE=${ZEEBE_AUTHENTICATION_MODE}
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL=http://keycloak:8080/auth/realms/camunda-platform
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE=zeebe-api
+      - ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL=http://identity:8084
+      - ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED=${MULTI_TENANCY_ENABLED}
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL=http://elasticsearch:9200
+      # default is 1000, see here: https://github.com/camunda/zeebe/blob/main/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java#L259
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE=1
+      # allow running with low disk space
+      - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
+      - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
+      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
+    restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1" ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - zeebe:/usr/local/zeebe/data
+    networks:
+      - camunda-platform
+    depends_on:
+      - elasticsearch
+      - identity
+
+  operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
+    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    container_name: operate
+    ports:
+      - "8081:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/operate-deployment/configuration/
+      - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
+      - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      # For more information regarding configuration with Identity see:
+      # https://docs.camunda.io/docs/self-managed/operate-deployment/authentication/#identity
+      - SPRING_PROFILES_ACTIVE=identity-auth
+      - CAMUNDA_OPERATE_IDENTITY_BASEURL=http://identity:8084
+      - CAMUNDA_OPERATE_IDENTITY_ISSUER_URL=http://${HOST}:18080/auth/realms/camunda-platform
+      - CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_OPERATE_IDENTITY_CLIENTID=operate
+      - CAMUNDA_OPERATE_IDENTITY_CLIENTSECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_OPERATE_IDENTITY_AUDIENCE=operate-api
+      - CAMUNDA_OPERATE_MULTITENANCY_ENABLED=${MULTI_TENANCY_ENABLED}
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/camunda-platform
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
+      - CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED=${RESOURCE_AUTHORIZATIONS_ENABLED}
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+      - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - operate_tmp:/tmp
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+      - identity
+      - elasticsearch
+
+  tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
+    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    container_name: tasklist
+    ports:
+      - "8082:8080"
+    environment: # https://docs.camunda.io/docs/self-managed/tasklist-deployment/configuration/
+      - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500
+      - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe:8080
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
+      - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      # For more information regarding configuration with Identity see:
+      # https://docs.camunda.io/docs/self-managed/tasklist-deployment/authentication/#identity
+      - SPRING_PROFILES_ACTIVE=identity-auth
+      - CAMUNDA_TASKLIST_IDENTITY_BASEURL=http://identity:8084
+      - CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL=http://${HOST}:18080/auth/realms/camunda-platform
+      - CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_TASKLIST_IDENTITY_CLIENTID=tasklist
+      - CAMUNDA_TASKLIST_IDENTITY_CLIENTSECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_TASKLIST_IDENTITY_AUDIENCE=tasklist-api
+      - CAMUNDA_TASKLIST_MULTITENANCY_ENABLED=${MULTI_TENANCY_ENABLED}
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:8080/auth/realms/camunda-platform
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
+      - CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED=${RESOURCE_AUTHORIZATIONS_ENABLED}
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - tasklist_tmp:/tmp
+    networks:
+      - camunda-platform
+    depends_on:
+      zeebe:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
+      identity:
+        condition: service_healthy
+
+  connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
+    container_name: connectors
+    ports:
+      - "8085:8080"
+    environment:
+      - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
+      - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
+      - ZEEBE_CLIENT_ID=${ZEEBE_CLIENT_ID}
+      - ZEEBE_CLIENT_SECRET=${ZEEBE_CLIENT_SECRET}
+      - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
+      - ZEEBE_TOKEN_AUDIENCE=zeebe-api
+      - ZEEBE_AUTHORIZATION_SERVER_URL=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token
+      - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
+      - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_CLIENT_ID=connectors
+      - CAMUNDA_IDENTITY_CLIENT_SECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_IDENTITY_TYPE=KEYCLOAK
+      - CAMUNDA_IDENTITY_AUDIENCE=operate-api
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    env_file: connector-secrets.txt
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    networks:
+      - camunda-platform
+    depends_on:
+      - zeebe
+      - operate
+      - identity
+
+  optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
+    image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
+    container_name: optimize
+    ports:
+      - "8083:8090"
+    environment: # https://docs.camunda.io/docs/self-managed/optimize-deployment/setup/installation/#available-environment-variables
+      - OPTIMIZE_ELASTICSEARCH_HOST=elasticsearch
+      - OPTIMIZE_ELASTICSEARCH_HTTP_PORT=9200
+      - SPRING_PROFILES_ACTIVE=ccsm
+      - CAMUNDA_OPTIMIZE_ZEEBE_ENABLED=true
+      - CAMUNDA_OPTIMIZE_ENTERPRISE=false
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL=http://${HOST}:18080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID=optimize
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE=optimize-api
+      - CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL=http://identity:8084
+      - CAMUNDA_OPTIMIZE_MULTITENANCY_ENABLED=${MULTI_TENANCY_ENABLED}
+      - CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED=false
+      - CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN=true
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8090/api/readyz" ]
+      interval: 30s
+      timeout: 1s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - "./.optimize/environment-config.yaml:/optimize/config/environment-config.yaml"
+    restart: on-failure
+    networks:
+      - camunda-platform
+    depends_on:
+      - identity
+      - elasticsearch
+
+  identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
+    container_name: identity
+    image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
+    ports:
+      - "8084:8084"
+    environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
+      SERVER_PORT: 8084
+      IDENTITY_RETRY_DELAY_SECONDS: 30
+      KEYCLOAK_URL: http://keycloak:8080/auth
+      IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
+      IDENTITY_DATABASE_HOST: postgres
+      IDENTITY_DATABASE_PORT: 5432
+      IDENTITY_DATABASE_NAME: bitnami_keycloak
+      IDENTITY_DATABASE_USERNAME: bn_keycloak
+      IDENTITY_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_INIT_OPERATE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_OPERATE_ROOT_URL: http://${HOST}:8081
+      KEYCLOAK_INIT_TASKLIST_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_TASKLIST_ROOT_URL: http://${HOST}:8082
+      KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://${HOST}:8083
+      KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://${HOST}:8070
+      KEYCLOAK_INIT_CONNECTORS_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_CONNECTORS_ROOT_URL: http://${HOST}:8085
+      KEYCLOAK_INIT_ZEEBE_NAME: zeebe
+      KEYCLOAK_USERS_0_USERNAME: "demo"
+      KEYCLOAK_USERS_0_PASSWORD: "demo"
+      KEYCLOAK_USERS_0_FIRST_NAME: "demo"
+      KEYCLOAK_USERS_0_EMAIL: "demo@acme.com"
+      KEYCLOAK_USERS_0_ROLES_0: "Identity"
+      KEYCLOAK_USERS_0_ROLES_1: "Optimize"
+      KEYCLOAK_USERS_0_ROLES_2: "Operate"
+      KEYCLOAK_USERS_0_ROLES_3: "Tasklist"
+      KEYCLOAK_USERS_0_ROLES_4: "Web Modeler"
+      KEYCLOAK_CLIENTS_0_NAME: zeebe
+      KEYCLOAK_CLIENTS_0_ID: ${ZEEBE_CLIENT_ID}
+      KEYCLOAK_CLIENTS_0_SECRET: ${ZEEBE_CLIENT_SECRET}
+      KEYCLOAK_CLIENTS_0_TYPE: M2M
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID: zeebe-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_RESOURCE_SERVER_ID: operate-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_RESOURCE_SERVER_ID: tasklist-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_RESOURCE_SERVER_ID: optimize-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_4_RESOURCE_SERVER_ID: tasklist-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_4_DEFINITION: read:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_5_RESOURCE_SERVER_ID: operate-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_5_DEFINITION: read:*
+      MULTITENANCY_ENABLED: ${MULTI_TENANCY_ENABLED}
+      RESOURCE_PERMISSIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health" ]
+      interval: 5s
+      timeout: 15s
+      retries: 30
+      start_period: 60s
+    restart: on-failure
+    volumes:
+      - keycloak-theme:/app/keycloak-theme
+    networks:
+      - camunda-platform
+      - identity-network
+    depends_on:
+      keycloak:
+        condition: service_healthy
+
+  postgres: # https://hub.docker.com/_/postgres
+    container_name: postgres
+    image: postgres:${POSTGRES_VERSION}
+    environment:
+      POSTGRES_DB: bitnami_keycloak
+      POSTGRES_USER: bn_keycloak
+      POSTGRES_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    networks:
+      - identity-network
+
+  keycloak: # https://hub.docker.com/r/bitnami/keycloak
+    container_name: keycloak
+    image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION}
+    volumes:
+      - keycloak-theme:/opt/bitnami/keycloak/themes/identity
+    ports:
+      - "18080:8080"
+    environment:
+      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
+      KEYCLOAK_DATABASE_HOST: postgres
+      KEYCLOAK_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_ADMIN_USER: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth" ]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
+    networks:
+      - camunda-platform
+      - identity-network
+    depends_on:
+      - postgres
+
+  elasticsearch: # https://hub.docker.com/_/elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+    container_name: elasticsearch
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      # allow running with low disk space
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    networks:
+      - camunda-platform
+
+  modeler-db:
+    profiles:
+      - web-modeler
+    container_name: modeler-db
+    image: postgres:${POSTGRES_VERSION}
+    healthcheck:
+      test: pg_isready -d modeler-db -U modeler-db-user
+      interval: 5s
+      timeout: 15s
+      retries: 30
+    environment:
+      POSTGRES_DB: modeler-db
+      POSTGRES_USER: modeler-db-user
+      POSTGRES_PASSWORD: modeler-db-password
+    networks:
+      - modeler
+    volumes:
+      - postgres-web:/var/lib/postgresql/data
+
+  mailpit:
+    # If you want to use your own SMTP server, you can remove this container
+    # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
+    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in modeler-restapi
+    profiles:
+      - web-modeler
+    container_name: mailpit
+    image: axllent/mailpit:${MAILPIT_VERSION}
+    ports:
+      - "1025:1025"
+      - "8075:8025"
+    healthcheck:
+      test: /usr/bin/nc -v localhost 1025
+      interval: 30s
+    networks:
+      - modeler
+
+  modeler-restapi:
+    profiles:
+      - web-modeler
+    container_name: modeler-restapi
+    image: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
+    depends_on:
+      modeler-db:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+      identity:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8091/health/readiness" ]
+      interval: 30s
+      retries: 10
+    environment:
+      JAVA_OPTIONS: -Xmx128m
+      LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
+      CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
+      SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db
+      SPRING_DATASOURCE_USERNAME: modeler-db-user
+      SPRING_DATASOURCE_PASSWORD: modeler-db-password
+      SPRING_PROFILES_INCLUDE: default-logging
+      RESTAPI_PUSHER_HOST: modeler-websockets
+      RESTAPI_PUSHER_PORT: "8060"
+      RESTAPI_PUSHER_APP_ID: modeler-app
+      RESTAPI_PUSHER_KEY: modeler-app-key
+      RESTAPI_PUSHER_SECRET: modeler-app-secret
+      RESTAPI_OAUTH2_TOKEN_ISSUER: http://localhost:18080/auth/realms/camunda-platform
+      RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
+      RESTAPI_SERVER_URL: http://localhost:8070
+      RESTAPI_MAIL_HOST: mailpit
+      RESTAPI_MAIL_PORT: 1025
+      RESTAPI_MAIL_ENABLE_TLS: "false"
+      RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
+    networks:
+      - modeler
+      - camunda-platform
+
+  modeler-webapp:
+    profiles:
+      - web-modeler
+    container_name: modeler-webapp
+    image: registry.camunda.cloud/web-modeler-ee/modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
+    ports:
+      - "8070:8070"
+    depends_on:
+      modeler-restapi:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8071/health/readiness" ]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+    environment:
+      RESTAPI_HOST: modeler-restapi
+      SERVER_HOST: modeler-webapp
+      SERVER_HTTPS_ONLY: "false"
+      SERVER_URL: http://localhost:8070
+      PUSHER_APP_ID: modeler-app
+      PUSHER_KEY: modeler-app-key
+      PUSHER_SECRET: modeler-app-secret
+      PUSHER_HOST: modeler-websockets
+      PUSHER_PORT: "8060"
+      CLIENT_PUSHER_HOST: localhost
+      CLIENT_PUSHER_PORT: "8060"
+      CLIENT_PUSHER_FORCE_TLS: "false"
+      CLIENT_PUSHER_KEY: modeler-app-key
+      OAUTH2_CLIENT_ID: web-modeler
+      OAUTH2_JWKS_URL: http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
+      OAUTH2_TOKEN_AUDIENCE: web-modeler
+      OAUTH2_TOKEN_ISSUER: http://localhost:18080/auth/realms/camunda-platform
+      IDENTITY_BASE_URL: http://identity:8084/
+      PLAY_ENABLED: "true"
+    networks:
+      - modeler
+      - camunda-platform
+
+  modeler-websockets:
+    profiles:
+      - web-modeler
+    container_name: modeler-websockets
+    image: registry.camunda.cloud/web-modeler-ee/modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
+    ports:
+      - "8060:8060"
+    healthcheck:
+      test: /usr/bin/nc -v localhost 8060
+      interval: 30s
+    environment:
+      APP_NAME: "Web Modeler Self-Managed WebSockets"
+      APP_DEBUG: "true"
+      PUSHER_APP_ID: modeler-app
+      PUSHER_APP_KEY: modeler-app-key
+      PUSHER_APP_SECRET: modeler-app-secret
+      PUSHER_APP_CLUSTER: modeler
+    networks:
+      - modeler
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
+    container_name: kibana
+    ports:
+      - 5601:5601
+    volumes:
+      - kibana:/usr/share/kibana/data
+    networks:
+      - camunda-platform
+    depends_on:
+      - elasticsearch
+    profiles:
+      - kibana
+
+volumes:
+  zeebe:
+  elastic:
+  postgres:
+  keycloak-theme:
+  kibana:
+  operate_tmp:
+  tasklist_tmp:
+  postgres-web:
+
+networks:
+  # Note there are three bridge networks: One for Camunda Platform, one for Identity and one for Web Modeler.
+  # Identity and Keycloak are part of the first two as they need to be accessible by platform components.
+  # Web Modeler has its own network because it consists of three components that communicate with each other.
+  # It is also part of the canunda-platform network to communicate with the platform components like Zeebe to run
+  # processes or Identity to log in.
+  camunda-platform:
+  identity-network:
+  modeler:


### PR DESCRIPTION
Needed to setup for a follow-up PR which implements: https://github.com/camunda/web-modeler/issues/9437

This PR introduces [compose profiles](https://docs.docker.com/compose/profiles/) to get rid of `docker-compose-web-modeler.yaml` and set up for the issue mentioned above.