### PR TITLE
feat: add web-modeler only setup

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ CAMUNDA_CONNECTORS_VERSION=8.5.3
 CAMUNDA_PLATFORM_VERSION=8.5.0
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.5.1
-# renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
+# renovate: datasource=docker depName=camunda/web-modeler-restapi
 CAMUNDA_WEB_MODELER_VERSION=8.5.1
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.13.4

--- a/docker-compose/camunda-8.6/.env
+++ b/docker-compose/camunda-8.6/.env
@@ -5,7 +5,7 @@ CAMUNDA_PLATFORM_VERSION=8.5.0
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.5.1
 # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
-CAMUNDA_WEB_MODELER_VERSION=8.5.1
+CAMUNDA_WEB_MODELER_VERSION=8.6.0-alpha2-rc1
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.13.4
 KEYCLOAK_SERVER_VERSION=21.1.2

--- a/docker-compose/camunda-8.6/README.md
+++ b/docker-compose/camunda-8.6/README.md
@@ -26,6 +26,10 @@ For production setups we recommend using [Helm charts](https://docs.camunda.io/d
 
 > :information_source: Docker 20.10.16+ is required.
 
+> :information_source: The Web Modeler service names have changed with 8.6.0-alpha2. If you still have old services running from the previous setup, run `docker compose stop modeler-webapp modeler-restapi modeler-websockets` additionally when tearing down the environment.
+
+Be sure you are in the correct directory when running all the following commands. Use `cd docker-compose/camunda-8.6` to navigate to the correct directory.
+
 To spin up a complete Camunda Platform 8 Self-Managed environment locally the [docker-compose.yaml](docker-compose.yaml) file in this repository can be used.
 
 The full environment contains these components:
@@ -38,13 +42,12 @@ The full environment contains these components:
 - Elasticsearch
 - Keycloak
 - PostgreSQL
-
-> :information_source: Web Modeler is not included by default. Please follow [the instructions below](#web-modeler-self-managed) to install it.
+- Web Modeler
 
 Clone this repo and issue the following command to start your environment:
 
 ```
-docker compose up -d
+docker compose --profile full up -d
 ```
 
 Wait a few minutes for the environment to start up and settle down. Monitor the logs, especially the Keycloak container log, to ensure the components have started.
@@ -55,6 +58,7 @@ Now you can navigate to the different web apps and log in with the user `demo` a
 - Optimize: [http://localhost:8083](http://localhost:8083)
 - Identity: [http://localhost:8084](http://localhost:8084)
 - Elasticsearch: [http://localhost:9200](http://localhost:9200)
+- Web Modeler: [http://localhost:8070](http://localhost:8070)
 
 Keycloak is used to manage users. Here you can log in with the user `admin` and password `admin`
 - Keycloak: [http://localhost:18080/auth/](http://localhost:18080/auth/)
@@ -64,14 +68,14 @@ The workflow engine Zeebe is available using gRPC at `localhost:26500`.
 To tear down the whole environment run the following command:
 
 ```
-docker compose down -v
+docker compose --profile full down -v
 ```
 
-Zeebe, Operate, Tasklist, along with Optimize require a separate network from Identity as you'll see in the docker-compose file.
+Zeebe, Operate, Tasklist, Web Modeler along with Optimize require a separate network from Identity as you'll see in the docker-compose file. Web Modeler also requires another separate network.
 
 ### Using the basic components
 
-If Optimize, Identity, and Keycloak are not needed you can use the [docker-compose-core.yaml](docker-compose-core.yaml) instead which does not include these components:
+If Optimize, Web Modeler, Identity, and Keycloak are not needed you can use the [docker-compose-core.yaml](docker-compose-core.yaml) instead which does not include these components:
 
 ```
 docker compose -f docker-compose-core.yaml up -d
@@ -152,31 +156,27 @@ If you enabled authentication for GRPC requests on Zeebe you need to provide cli
 
 ## Web Modeler Self-Managed
 
-> :information_source: Web Modeler Self-Managed is available to Camunda enterprise customers only.
+> :information_source: Web Modeler Self-Managed images with version <8.6.0-alpha2 are available to Camunda enterprise customers only. Follow the instructions in the root folder [README](../../README.md) to set up the environment for these versions.
 
-The Docker images for Web Modeler are available in a private registry. Enterprise customers either already have credentials to this registry, or they can request access to this registry through their CSM contact at Camunda.
+Web Modeler can be run standalone with only Identity and Keycloak as dependencies.
 
-To run Camunda Platform with Web Modeler Self-Managed clone this repo and issue the following commands:
+Issue the following commands to only start Web Modeler and its dependencies:
 
 ```
-$ docker login registry.camunda.cloud
-Username: your_username
-Password: ******
-Login Succeeded
-$ docker compose --profile web-modeler up -d
+docker compose --profile web-modeler-only up -d
 ```
 
 To tear down the whole environment run the following command
 
 ```
-$ docker compose --profile web-modeler down -v
+docker compose --profile web-modeler-only down -v
 ```
 
 If you want to delete everything (including any data you created).
 Alternatively, if you want to keep the data run:
 
 ```
-$ docker compose --profile web-modeler down
+docker compose --profile web-modeler-only down
 ```
 
 ### Login
@@ -229,7 +229,7 @@ This feature is disabled by default and can be enabled by setting
 `RESOURCE_AUTHORIZATIONS_ENABLED` to `true`, either via the [`.env`](.env) file or through the command line:
 
 ```
-RESOURCE_AUTHORIZATIONS_ENABLED=true docker compose up -d
+RESOURCE_AUTHORIZATIONS_ENABLED=true docker compose --profile full up -d
 ```
 
 ## Multi-Tenancy
@@ -240,7 +240,7 @@ This feature is disabled by default and can be enabled by setting
 `MULTI_TENANCY_ENABLED` to `true`, either via the [`.env`](.env) file or through the command line:
 
 ```
-ZEEBE_AUTHENICATION_MODE=identity MULTI_TENANCY_ENABLED=true docker compose up -d
+ZEEBE_AUTHENICATION_MODE=identity MULTI_TENANCY_ENABLED=true docker compose --profile full up -d
 ```
 
 As seen above the feature also requires you to use `identity` as an authentication provider.

--- a/docker-compose/camunda-8.6/README.md
+++ b/docker-compose/camunda-8.6/README.md
@@ -26,7 +26,7 @@ For production setups we recommend using [Helm charts](https://docs.camunda.io/d
 
 > :information_source: Docker 20.10.16+ is required.
 
-> :information_source: The Web Modeler service names have changed with 8.6.0-alpha2. If you still have old services running from the previous setup, run `docker compose stop modeler-webapp modeler-restapi modeler-websockets` additionally when tearing down the environment.
+> :information_source: The Web Modeler service names have changed with `8.6.0-alpha2`. Run `docker compose stop modeler-webapp modeler-restapi modeler-websockets` when upgrading from a previous version to stop the old services.
 
 Be sure you are in the correct directory when running all the following commands. Use `cd docker-compose/camunda-8.6` to navigate to the correct directory.
 
@@ -42,7 +42,7 @@ The full environment contains these components:
 - Elasticsearch
 - Keycloak
 - PostgreSQL
-- Web Modeler
+- Web Modeler (Restapi, Webapp and Websockets)
 
 Clone this repo and issue the following command to start your environment:
 
@@ -156,27 +156,27 @@ If you enabled authentication for GRPC requests on Zeebe you need to provide cli
 
 ## Web Modeler Self-Managed
 
-> :information_source: Web Modeler Self-Managed images with version <8.6.0-alpha2 are available to Camunda enterprise customers only. Follow the instructions in the root folder [README](../../README.md) to set up the environment for these versions.
+> :information_source: Web Modeler is currently restricted to five collaborators per project. Read more about the restriction [here](https://docs.camunda.io/docs/components/modeler/web-modeler/collaboration/).
 
-Web Modeler can be run standalone with only Identity and Keycloak as dependencies.
+Web Modeler can be run standalone with only Identity, Keycloak and Postgres as dependencies.
 
 Issue the following commands to only start Web Modeler and its dependencies:
 
 ```
-docker compose --profile web-modeler-only up -d
+docker compose --profile modeling up -d
 ```
 
 To tear down the whole environment run the following command
 
 ```
-docker compose --profile web-modeler-only down -v
+docker compose --profile modeling down -v
 ```
 
 If you want to delete everything (including any data you created).
 Alternatively, if you want to keep the data run:
 
 ```
-docker compose --profile web-modeler-only down
+docker compose --profile modeling down
 ```
 
 ### Login

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -372,21 +372,21 @@ services:
     networks:
       - camunda-platform
 
-  modeler-db:
+  web-modeler-db:
     profiles:
       - full
       - web-modeler-only
-    container_name: modeler-db
+    container_name: web-modeler-db
     image: postgres:${POSTGRES_VERSION}
     healthcheck:
-      test: pg_isready -d modeler-db -U modeler-db-user
+      test: pg_isready -d web-modeler-db -U web-modeler-db-user
       interval: 5s
       timeout: 15s
       retries: 30
     environment:
-      POSTGRES_DB: modeler-db
-      POSTGRES_USER: modeler-db-user
-      POSTGRES_PASSWORD: modeler-db-password
+      POSTGRES_DB: web-modeler-db
+      POSTGRES_USER: web-modeler-db-user
+      POSTGRES_PASSWORD: web-modeler-db-password
     networks:
       - web-modeler
     volumes:
@@ -418,7 +418,7 @@ services:
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
     command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
-      modeler-db:
+      web-modeler-db:
         condition: service_healthy
       mailpit:
         condition: service_started
@@ -432,9 +432,9 @@ services:
       JAVA_OPTIONS: -Xmx128m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db
-      SPRING_DATASOURCE_USERNAME: modeler-db-user
-      SPRING_DATASOURCE_PASSWORD: modeler-db-password
+      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db
+      SPRING_DATASOURCE_USERNAME: web-modeler-db-user
+      SPRING_DATASOURCE_PASSWORD: web-modeler-db-password
       SPRING_PROFILES_INCLUDE: default-logging
       RESTAPI_PUSHER_HOST: web-modeler-websockets
       RESTAPI_PUSHER_PORT: "8060"

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -224,7 +224,7 @@ services:
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: identity
     image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
     ports:
@@ -295,7 +295,7 @@ services:
   postgres: # https://hub.docker.com/_/postgres
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: postgres
     image: postgres:${POSTGRES_VERSION}
     environment:
@@ -316,7 +316,7 @@ services:
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: keycloak
     image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION}
     volumes:
@@ -375,7 +375,7 @@ services:
   web-modeler-db:
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: web-modeler-db
     image: postgres:${POSTGRES_VERSION}
     healthcheck:
@@ -398,7 +398,7 @@ services:
     # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
@@ -413,7 +413,7 @@ services:
   web-modeler-restapi:
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
     command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
@@ -456,7 +456,7 @@ services:
   web-modeler-webapp:
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: web-modeler-webapp
     image: camunda/web-modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
@@ -496,7 +496,7 @@ services:
   web-modeler-websockets:
     profiles:
       - full
-      - web-modeler-only
+      - modeling
     container_name: web-modeler-websockets
     image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -6,12 +6,14 @@
 # For local development, we recommend using KIND instead of `docker-compose`:
 # https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/
 
-# This is a full configuration with Zeebe, Operate, Tasklist, Optimize, Identity, Keycloak, Elasticsearch and optional Web Modeler.
+# This is a full configuration with Zeebe, Operate, Tasklist, Optimize, Identity, Keycloak, Elasticsearch and Web Modeler.
 # See docker-compose-core.yml for a lightweight configuration that does not include Optimize, Identity, and Keycloak.
 
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
+    profiles:
+      - full
     image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
     container_name: zeebe
     ports:
@@ -48,6 +50,8 @@ services:
       - identity
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
+    profiles:
+      - full
     image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
     container_name: operate
     ports:
@@ -92,6 +96,8 @@ services:
       - elasticsearch
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
+    profiles:
+      - full
     image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
     container_name: tasklist
     ports:
@@ -140,6 +146,8 @@ services:
         condition: service_healthy
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
+    profiles:
+      - full
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
     container_name: connectors
     ports:
@@ -175,6 +183,8 @@ services:
       - identity
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
+    profiles:
+      - full
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
     container_name: optimize
     ports:
@@ -212,6 +222,9 @@ services:
       - elasticsearch
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
+    profiles:
+      - full
+      - web-modeler-only
     container_name: identity
     image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
     ports:
@@ -280,6 +293,9 @@ services:
         condition: service_healthy
 
   postgres: # https://hub.docker.com/_/postgres
+    profiles:
+      - full
+      - web-modeler-only
     container_name: postgres
     image: postgres:${POSTGRES_VERSION}
     environment:
@@ -298,6 +314,9 @@ services:
       - identity-network
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
+    profiles:
+      - full
+      - web-modeler-only
     container_name: keycloak
     image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION}
     volumes:
@@ -324,6 +343,8 @@ services:
       - postgres
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
+    profiles:
+      - full
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
     container_name: elasticsearch
     ports:
@@ -353,7 +374,8 @@ services:
 
   modeler-db:
     profiles:
-      - web-modeler
+      - full
+      - web-modeler-only
     container_name: modeler-db
     image: postgres:${POSTGRES_VERSION}
     healthcheck:
@@ -366,16 +388,17 @@ services:
       POSTGRES_USER: modeler-db-user
       POSTGRES_PASSWORD: modeler-db-password
     networks:
-      - modeler
+      - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
     # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
-    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in modeler-restapi
+    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
     profiles:
-      - web-modeler
+      - full
+      - web-modeler-only
     container_name: mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
@@ -385,13 +408,14 @@ services:
       test: /usr/bin/nc -v localhost 1025
       interval: 30s
     networks:
-      - modeler
-
-  modeler-restapi:
-    profiles:
       - web-modeler
-    container_name: modeler-restapi
-    image: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+
+  web-modeler-restapi:
+    profiles:
+      - full
+      - web-modeler-only
+    container_name: web-modeler-restapi
+    image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
     command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       modeler-db:
@@ -412,7 +436,7 @@ services:
       SPRING_DATASOURCE_USERNAME: modeler-db-user
       SPRING_DATASOURCE_PASSWORD: modeler-db-password
       SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: modeler-websockets
+      RESTAPI_PUSHER_HOST: web-modeler-websockets
       RESTAPI_PUSHER_PORT: "8060"
       RESTAPI_PUSHER_APP_ID: modeler-app
       RESTAPI_PUSHER_KEY: modeler-app-key
@@ -425,18 +449,19 @@ services:
       RESTAPI_MAIL_ENABLE_TLS: "false"
       RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
     networks:
-      - modeler
+      - web-modeler
       - camunda-platform
 
-  modeler-webapp:
+  web-modeler-webapp:
     profiles:
-      - web-modeler
-    container_name: modeler-webapp
-    image: registry.camunda.cloud/web-modeler-ee/modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
+      - full
+      - web-modeler-only
+    container_name: web-modeler-webapp
+    image: camunda/web-modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8070:8070"
     depends_on:
-      modeler-restapi:
+      web-modeler-restapi:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8071/health/readiness" ]
@@ -444,8 +469,8 @@ services:
       timeout: 15s
       retries: 5
     environment:
-      RESTAPI_HOST: modeler-restapi
-      SERVER_HOST: modeler-webapp
+      RESTAPI_HOST: web-modeler-restapi
+      SERVER_HOST: web-modeler-webapp
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
       PUSHER_APP_ID: modeler-app
@@ -464,14 +489,15 @@ services:
       IDENTITY_BASE_URL: http://identity:8084/
       PLAY_ENABLED: "true"
     networks:
-      - modeler
+      - web-modeler
       - camunda-platform
 
-  modeler-websockets:
+  web-modeler-websockets:
     profiles:
-      - web-modeler
-    container_name: modeler-websockets
-    image: registry.camunda.cloud/web-modeler-ee/modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
+      - full
+      - web-modeler-only
+    container_name: web-modeler-websockets
+    image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8060:8060"
     healthcheck:
@@ -485,7 +511,7 @@ services:
       PUSHER_APP_SECRET: modeler-app-secret
       PUSHER_APP_CLUSTER: modeler
     networks:
-      - modeler
+      - web-modeler
 
   kibana:
     image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
@@ -519,4 +545,4 @@ networks:
   # processes or Identity to log in.
   camunda-platform:
   identity-network:
-  modeler:
+  web-modeler:

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -426,8 +426,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8091/health/readiness" ]
-      interval: 30s
-      retries: 10
+      interval: 5s
+      timeout: 15s
+      retries: 30
     environment:
       JAVA_OPTIONS: -Xmx128m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
@@ -465,9 +466,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8071/health/readiness" ]
-      interval: 30s
+      interval: 5s
       timeout: 15s
-      retries: 5
+      retries: 30
     environment:
       RESTAPI_HOST: web-modeler-restapi
       SERVER_HOST: web-modeler-webapp
@@ -502,7 +503,9 @@ services:
       - "8060:8060"
     healthcheck:
       test: /usr/bin/nc -v localhost 8060
-      interval: 30s
+      interval: 5s
+      timeout: 15s
+      retries: 30
     environment:
       APP_NAME: "Web Modeler Self-Managed WebSockets"
       APP_DEBUG: "true"

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -438,9 +438,9 @@ services:
       SPRING_PROFILES_INCLUDE: default-logging
       RESTAPI_PUSHER_HOST: web-modeler-websockets
       RESTAPI_PUSHER_PORT: "8060"
-      RESTAPI_PUSHER_APP_ID: modeler-app
-      RESTAPI_PUSHER_KEY: modeler-app-key
-      RESTAPI_PUSHER_SECRET: modeler-app-secret
+      RESTAPI_PUSHER_APP_ID: web-modeler-app
+      RESTAPI_PUSHER_KEY: web-modeler-app-key
+      RESTAPI_PUSHER_SECRET: web-modeler-app-secret
       RESTAPI_OAUTH2_TOKEN_ISSUER: http://localhost:18080/auth/realms/camunda-platform
       RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
       RESTAPI_SERVER_URL: http://localhost:8070
@@ -473,15 +473,15 @@ services:
       SERVER_HOST: web-modeler-webapp
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
-      PUSHER_APP_ID: modeler-app
-      PUSHER_KEY: modeler-app-key
-      PUSHER_SECRET: modeler-app-secret
-      PUSHER_HOST: modeler-websockets
+      PUSHER_APP_ID: web-modeler-app
+      PUSHER_KEY: web-modeler-app-key
+      PUSHER_SECRET: web-modeler-app-secret
+      PUSHER_HOST: web-modeler-websockets
       PUSHER_PORT: "8060"
       CLIENT_PUSHER_HOST: localhost
       CLIENT_PUSHER_PORT: "8060"
       CLIENT_PUSHER_FORCE_TLS: "false"
-      CLIENT_PUSHER_KEY: modeler-app-key
+      CLIENT_PUSHER_KEY: web-modeler-app-key
       OAUTH2_CLIENT_ID: web-modeler
       OAUTH2_JWKS_URL: http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
       OAUTH2_TOKEN_AUDIENCE: web-modeler
@@ -506,10 +506,10 @@ services:
     environment:
       APP_NAME: "Web Modeler Self-Managed WebSockets"
       APP_DEBUG: "true"
-      PUSHER_APP_ID: modeler-app
-      PUSHER_APP_KEY: modeler-app-key
-      PUSHER_APP_SECRET: modeler-app-secret
-      PUSHER_APP_CLUSTER: modeler
+      PUSHER_APP_ID: web-modeler-app
+      PUSHER_APP_KEY: web-modeler-app-key
+      PUSHER_APP_SECRET: web-modeler-app-secret
+      PUSHER_APP_CLUSTER: web-modeler
     networks:
       - web-modeler
 

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -502,7 +502,7 @@ services:
     ports:
       - "8060:8060"
     healthcheck:
-      test: /usr/bin/nc -v localhost 8060
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8060/up" ]
       interval: 5s
       timeout: 15s
       retries: 30
@@ -512,7 +512,6 @@ services:
       PUSHER_APP_ID: web-modeler-app
       PUSHER_APP_KEY: web-modeler-app-key
       PUSHER_APP_SECRET: web-modeler-app-secret
-      PUSHER_APP_CLUSTER: web-modeler
     networks:
       - web-modeler
 


### PR DESCRIPTION
Closes https://github.com/camunda/web-modeler/issues/9437.

This PR introduces the possibility to run web modeler stand alone with all needed dependencies (Identity + Keycloak) and uses the new public Docker Hub repositories for pulling Web Modeler images.

The `test-modeler.yaml` ci-test still needs to be adjusted to test the version in this `docker-compose/camunda-8.6` directory (only the docker-compose setup in the root directory gets tested). I could not get it done in a fixed time frame and should be done in a follow-up issue.

The Web Modeler version needs to be changed with the alpha2 release.

Final review should be done by Ahmed.