### PR TITLE
fix: use correct 8.6.0-alpha2 versions + disable Renovate auto-merge for release candidates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,8 +106,13 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
     },
+    // disable auto-merge for alpha release candidates
     {
-      // we manually made this package for renovate. 
+      "matchNewValue": "/.*alpha[0-9]*-rc[0-9]*/",
+      "automerge": false
+    },
+    {
+      // we manually made this package for renovate.
       // no need to update it again
       "matchDepNames": ["docker.io/bitnami/keycloak"],
       "enabled": false,

--- a/docker-compose/camunda-8.6/.env
+++ b/docker-compose/camunda-8.6/.env
@@ -1,11 +1,11 @@
 ## Image versions ##
 # renovate: datasource=docker depName=camunda/connectors-bundle
-CAMUNDA_CONNECTORS_VERSION=8.6.0-alpha2-rc2
+CAMUNDA_CONNECTORS_VERSION=8.6.0-alpha2.1
 CAMUNDA_PLATFORM_VERSION=8.6.0-alpha2
 # renovate: datasource=docker depName=camunda/optimize
-CAMUNDA_OPTIMIZE_VERSION=8.6.0-alpha2-rc2
+CAMUNDA_OPTIMIZE_VERSION=8.6.0-alpha2
 # renovate: datasource=docker depName=camunda/web-modeler-restapi
-CAMUNDA_WEB_MODELER_VERSION=8.6.0-alpha2-rc1
+CAMUNDA_WEB_MODELER_VERSION=8.6.0-alpha2
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.14.0
 KEYCLOAK_SERVER_VERSION=21.1.2


### PR DESCRIPTION
Reverts the changes from [#671](https://github.com/camunda/camunda-platform/pull/671), [#668](https://github.com/camunda/camunda-platform/pull/668), and [#669](https://github.com/camunda/camunda-platform/pull/669).

See also this [Slack thread](https://camunda.slack.com/archives/C03NFMH4KC6/p1717749571220849).