### PR TITLE
fix: use camunda/camunda repo for operate and zeebe

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -81,7 +81,7 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "${ZEEBE_GITREF}" \
-            -R camunda/zeebe  \
+            -R camunda/camunda  \
             -p "zbctl"  \
             -p "zbctl.sha1sum" \
             -p "zbctl.exe"  \
@@ -113,7 +113,7 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "${OPERATE_GITREF}" \
-            -R camunda/camunda \
+            -R camunda/operate \
             -p "camunda-operate-${OPERATE_GITREF}.zip" \
             -p "camunda-operate-${OPERATE_GITREF}.zip.sha1sum" \
             -p "camunda-operate-${OPERATE_GITREF}.tar.gz" \

--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "operate-${OPERATE_GITREF}" \
-            -R camunda/zeebe \
+            -R camunda/camunda \
             -p "camunda-operate-${OPERATE_GITREF}.zip" \
             -p "camunda-operate-${OPERATE_GITREF}.zip.sha1sum" \
             -p "camunda-operate-${OPERATE_GITREF}.tar.gz" \
@@ -113,7 +113,7 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "${OPERATE_GITREF}" \
-            -R camunda/operate \
+            -R camunda/camunda \
             -p "camunda-operate-${OPERATE_GITREF}.zip" \
             -p "camunda-operate-${OPERATE_GITREF}.zip.sha1sum" \
             -p "camunda-operate-${OPERATE_GITREF}.tar.gz" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: >
           gh release
           download "$GITHUB_REF_NAME"
-          -R camunda/zeebe
+          -R camunda/camunda
           -p "zbctl"
           -p "zbctl.sha1sum"
           -p "zbctl.exe"
@@ -82,7 +82,7 @@ jobs:
         run: >
           gh release
           download "operate-$GITHUB_REF_NAME"
-          -R camunda/zeebe
+          -R camunda/camunda
           -p "camunda-operate-$GITHUB_REF_NAME.zip"
           -p "camunda-operate-$GITHUB_REF_NAME.zip.sha1sum"
           -p "camunda-operate-$GITHUB_REF_NAME.tar.gz"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ./release-notes-fetcher
         # The var CAMUNDA_RELEASE_NAME should be the same as GITHUB_REF_NAME but it's hard-coded as 8.3.1 tag
         # and we just want to see if a valid version can fetch notes
-        run: set -o pipefail; CAMUNDA_RELEASE_NAME=8.3.1 ./release-notes-fetcher | tee release_notes.txt
+        run: set -o pipefail; CAMUNDA_RELEASE_NAME=8.5.1 ./release-notes-fetcher | tee release_notes.txt
         env:
           GITHUB_CAMUNDA_ACCESS_TOKEN: ${{ steps.generate-camunda-github-token.outputs.token }}
           GITHUB_CAMUNDA_CLOUD_ACCESS_TOKEN: ${{ steps.generate-camunda-cloud-github-token.outputs.token }}

--- a/release-notes-fetcher/fetch.go
+++ b/release-notes-fetcher/fetch.go
@@ -17,8 +17,8 @@ import (
 const RepoOwner = "camunda"
 const CloudRepoOwner = "camunda-cloud"
 const MainRepoName = "camunda-platform"
-const ZeebeRepoName = "zeebe"
-const OperateRepoName = "operate"
+const ZeebeRepoName = "camunda"
+const OperateRepoName = "camunda"
 const TasklistRepoName = "tasklist"
 const IdentityRepoName = "identity"
 const ReleaseNotesTemplateFileName = "release-notes-template.txt"
@@ -142,6 +142,10 @@ func main() {
 	camundaRepoService := camundaGithubClient.Repositories
 
 	log.Debug().Msg("Camunda Github ref = " + camundaReleaseVersion)
+	log.Debug().Msg("Zeebe Github ref = " + camundaAppVersions.Zeebe)
+	log.Debug().Msg("Tasklist Github ref = " + camundaAppVersions.Tasklist)
+	log.Debug().Msg("Operate Github ref = " + camundaAppVersions.Operate)
+	log.Debug().Msg("Identity Github ref = " + camundaAppVersions.Identity)
 
 	zeebeReleaseNotes := GetLatestReleaseContents(
 		ctx,
@@ -156,7 +160,7 @@ func main() {
 		RepoOwner,
 		OperateRepoName,
 		camundaRepoService,
-		camundaAppVersions.Operate,
+		"operate-" + camundaAppVersions.Operate,
 	)
 
 	tasklistReleaseNotesContents := GetChangelogReleaseContents(


### PR DESCRIPTION

The recent change to move from repo `camunda/zeebe` to `camunda/camunda` means that the release notes fetcher should be looking at the new camunda repo for release notes.  Inside the camunda/camunda repo, operate releases are specified under the `operate-8.x.y` tag, so in this code change, operate will now append `operate-` to the tag name it's searching for.