### PR TITLE
Add ci-tests for 8.6 directory

### DIFF
--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -15,6 +15,10 @@ on:
         description: directory to run the tests
         required: false
         type: string
+      run_single_test:
+        description: runs a single test
+        required: false
+        type: string
 
 jobs:
   test_compose_deploy:
@@ -67,28 +71,33 @@ jobs:
           ""
 
       - uses: actions/setup-node@v4
-        if: ${{ inputs.run_e2e_tests }}
+        if: ${{ inputs.run_e2e_tests || inputs.run_single_test }}
         with:
           node-version: 18
 
       - name: Install dependencies
-        if: ${{ inputs.run_e2e_tests }}
+        if: ${{ inputs.run_e2e_tests || inputs.run_single_test }}
         run: npm ci
         working-directory: ./e2e_tests
 
       - name: Install Playwright Browsers
-        if: ${{ inputs.run_e2e_tests }}
+        if: ${{ inputs.run_e2e_tests || inputs.run_single_test }}
         run: npx playwright install --with-deps
         working-directory: ./e2e_tests
 
       - name: Run Playwright tests
-        if: ${{ inputs.run_e2e_tests }}
+        if: ${{ inputs.run_e2e_tests && inputs.run_single_test == '' }}
         run: npx playwright test
         working-directory: ./e2e_tests
 
+      - name: Run single Playwright test '${{ inputs.run_single_test }}'
+        if: ${{ inputs.run_e2e_tests && inputs.run_single_test }}
+        run: npx playwright test ${{ inputs.run_single_test }}
+        working-directory: ./e2e_tests
+
       - uses: actions/upload-artifact@v4
-        if: ${{ inputs.run_e2e_tests }}
+        if: ${{ inputs.run_e2e_tests || inputs.run_single_test }}
         with:
-          name: playwright-report
+          name: playwright-report${{ inputs.run_single_test && '-single-test' || '' }}
           path: e2e_tests/playwright-report/
           retention-days: 30

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -11,6 +11,10 @@ on:
         description: runs playwright tests
         required: true
         type: boolean
+      directory:
+        description: directory to run the tests
+        required: false
+        type: string
 
 jobs:
   test_compose_deploy:
@@ -28,10 +32,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to private registry
+        if: ${{ inputs.directory != 'docker-compose/camunda-8.6' }}
         run: >-
           echo '${{ secrets.CI_DISTRIBUTION_REGISTRY_PASSWORD }}' | docker login -u ci-distribution --password-stdin  registry.camunda.cloud
 
       - name: Bring up containers
+        working-directory: ${{ inputs.directory || '.' }}
         run: >-
           docker compose ${{ inputs.compose_args }}
           up

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -5,9 +5,20 @@ on:
       - "**"
 jobs:
   test_core:
+    strategy:
+      matrix:
+        include:
+          - compose_args: "-f docker-compose-core.yaml"
+            run_e2e_tests: false
+            directory: ""
+          - compose_args: "-f docker-compose-core.yaml"
+            run_e2e_tests: false
+            directory: "docker-compose/camunda-8.6"
     uses: ./.github/workflows/template-deploy.yaml
+    name: Test deploying from directory "${{ matrix.directory || 'root' }}"
     secrets: inherit
     with:
-      compose_args: "-f docker-compose-core.yaml"
-      run_e2e_tests: false
+      compose_args: ${{ matrix.compose_args }}
+      run_e2e_tests: ${{ matrix.run_e2e_tests }}
+      directory: ${{ matrix.directory }}
 

--- a/.github/workflows/test-default.yaml
+++ b/.github/workflows/test-default.yaml
@@ -5,9 +5,19 @@ on:
       - "**"
 jobs:
   test_docker_compose_yaml:
+    strategy:
+      matrix:
+        include:
+          - compose_args: "-f docker-compose.yaml"
+            run_e2e_tests: false
+            directory: ""
+          - compose_args: "--profile full"
+            run_e2e_tests: false
+            directory: "docker-compose/camunda-8.6"
     uses: ./.github/workflows/template-deploy.yaml
+    name: Test deploying from directory "${{ matrix.directory || 'root' }}"
     secrets: inherit
     with:
-      compose_args: "-f docker-compose.yaml"
-      run_e2e_tests: false
-
+      compose_args: ${{ matrix.compose_args }}
+      run_e2e_tests: ${{ matrix.run_e2e_tests }}
+      directory: ${{ matrix.directory }}

--- a/.github/workflows/test-modeler.yaml
+++ b/.github/workflows/test-modeler.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "**"
+
 jobs:
   test_modeler_yaml:
     strategy:
@@ -12,7 +13,8 @@ jobs:
             run_e2e_tests: true
             directory: ""
           - compose_args: "--profile modeling"
-            run_e2e_tests: false
+            run_e2e_tests: true
+            run_single_test: "web_modeler_login.spec.ts"
             directory: "docker-compose/camunda-8.6"
     uses: ./.github/workflows/template-deploy.yaml
     name: Test deploying from directory "${{ matrix.directory || 'root' }}"
@@ -21,3 +23,4 @@ jobs:
       compose_args: ${{ matrix.compose_args }}
       run_e2e_tests: ${{ matrix.run_e2e_tests }}
       directory: ${{ matrix.directory }}
+      run_single_test: ${{ matrix.run_single_test }}

--- a/.github/workflows/test-modeler.yaml
+++ b/.github/workflows/test-modeler.yaml
@@ -10,3 +10,10 @@ jobs:
     with:
       compose_args: "-f docker-compose.yaml -f docker-compose-web-modeler.yaml"
       run_e2e_tests: true
+  test_modeler_yaml_8_6:
+    uses: ./.github/workflows/template-deploy.yaml
+    secrets: inherit
+    with:
+      compose_args: "--profile full"
+      run_e2e_tests: true
+      directory: "docker-compose/camunda-8.6"

--- a/.github/workflows/test-modeler.yaml
+++ b/.github/workflows/test-modeler.yaml
@@ -5,15 +5,19 @@ on:
       - "**"
 jobs:
   test_modeler_yaml:
+    strategy:
+      matrix:
+        include:
+          - compose_args: "-f docker-compose.yaml -f docker-compose-web-modeler.yaml"
+            run_e2e_tests: true
+            directory: ""
+          - compose_args: "--profile modeling"
+            run_e2e_tests: false
+            directory: "docker-compose/camunda-8.6"
     uses: ./.github/workflows/template-deploy.yaml
+    name: Test deploying from directory "${{ matrix.directory || 'root' }}"
     secrets: inherit
     with:
-      compose_args: "-f docker-compose.yaml -f docker-compose-web-modeler.yaml"
-      run_e2e_tests: true
-  test_modeler_yaml_8_6:
-    uses: ./.github/workflows/template-deploy.yaml
-    secrets: inherit
-    with:
-      compose_args: "--profile full"
-      run_e2e_tests: true
-      directory: "docker-compose/camunda-8.6"
+      compose_args: ${{ matrix.compose_args }}
+      run_e2e_tests: ${{ matrix.run_e2e_tests }}
+      directory: ${{ matrix.directory }}

--- a/docker-compose/camunda-8.6/.optimize/environment-config.yaml
+++ b/docker-compose/camunda-8.6/.optimize/environment-config.yaml
@@ -1,0 +1,5 @@
+es:
+  settings:
+    index:
+      number_of_replicas: 0
+

--- a/docker-compose/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/camunda-8.6/docker-compose-core.yaml
@@ -54,7 +54,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5
@@ -79,7 +79,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/camunda-8.6/docker-compose-core.yaml
@@ -50,6 +50,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
@@ -74,6 +75,7 @@ services:
       - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe:8080
       - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
       - management.endpoint.health.probes.enabled=true
       - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5
@@ -128,7 +128,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/camunda-8.6/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
       - management.endpoint.health.probes.enabled=true
       - ZEEBE_CLIENT_CONFIG_PATH=/tmp/zeebe_auth_cache
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5
@@ -128,7 +128,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:8080/actuator/health/readiness'" ]
+      test: [ "CMD-SHELL", "wget -O - -q 'http://localhost:9600/actuator/health/readiness'" ]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/e2e_tests/tests/web_modeler_login.spec.ts
+++ b/e2e_tests/tests/web_modeler_login.spec.ts
@@ -9,6 +9,6 @@ test('test', async ({ page }) => {
   await page.getByLabel('Password').click();
   await page.getByLabel('Password').fill('demo');
   await page.getByRole('button', { name: 'Log in' }).click();
-  await page.getByText('Welcome, demo').waitFor();
+  await page.getByText('Projects').waitFor();
   await page.locator('[data-test="create-project"]').click();
 });


### PR DESCRIPTION
Closes https://github.com/camunda/web-modeler/issues/9822

With https://github.com/camunda/web-modeler/issues/9437 I introduced a new folder `docker-compose/camunda-8.6` which is not part of the ci test pipeline. With this PR I extended the pipeline to also run tests in the directory.