### PR TITLE
fix: adapting operate to get from the right repo

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -97,8 +97,16 @@ jobs:
             -p "camunda-tasklist-${ZEEBE_GITREF}.tar.gz" \
             -p "camunda-tasklist-${ZEEBE_GITREF}.tar.gz.sha1sum"
 
+      - name: Parse major version number
+        id: get-major-version
+        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '-' '{print $1} | IFS=. read major minor patch && echo "MAJOR_VERSION=$major" >> "$GITHUB_OUTPUT"
+
+      - name: Parse minor version number
+        id: get-minor-version
+        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '-' '{print $1} | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
+
       - name: Download Operate resources from monorepo
-        if: ${{ startsWith(env.CAMUNDA_RELEASE_NAME, '8.5') }}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 5 }}
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "operate-${OPERATE_GITREF}" \
@@ -109,7 +117,7 @@ jobs:
             -p "camunda-operate-${OPERATE_GITREF}.tar.gz.sha1sum" \
 
       - name: Download Operate resources
-        if: ${{ !startsWith(env.CAMUNDA_RELEASE_NAME, '8.5') }}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION < 5 }}
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "${OPERATE_GITREF}" \

--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Example: 8.4-gen1
-      - 8\.\d+\-gen\d+
+      - 8\.\d+\+gen\d+
       # Example: 8.6.0-alpha1
       - 8\.\d+\-alpha\d+
 

--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set Camunda application vars
         run: |
-          CAMUNDA_VERSION="$(echo ${CAMUNDA_RELEASE_NAME} | awk -F '-' '{print $1}')"
+          CAMUNDA_VERSION="$(echo ${CAMUNDA_RELEASE_NAME} | awk -F '+' '{print $1}')"
           CONFIG_FILE="release-notes-fetcher/config/release-notes-fetcher-camunda-${CAMUNDA_VERSION}.yaml"
           export GLOBAL_GITREF="$(yq '.gitRef.global' ${CONFIG_FILE})"
 
@@ -99,11 +99,11 @@ jobs:
 
       - name: Parse major version number
         id: get-major-version
-        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '-' '{print $1} | IFS=. read major minor patch && echo "MAJOR_VERSION=$major" >> "$GITHUB_OUTPUT"
+        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '+' '{print $1}' | (IFS=. read major minor patch && echo "MAJOR_VERSION=$major") >> "$GITHUB_OUTPUT"
 
       - name: Parse minor version number
         id: get-minor-version
-        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '-' '{print $1} | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
+        run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '+' '{print $1}' | (IFS=. read major minor patch && echo "MINOR_VERSION=$minor") >> "$GITHUB_OUTPUT"
 
       - name: Download Operate resources from monorepo
         if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 5 }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,8 +76,16 @@ jobs:
           -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz"
           -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
+      - name: Parse major version number
+        id: get-major-version
+        run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MAJOR_VERSION=$major" >> "$GITHUB_OUTPUT"
+
+      - name: Parse minor version number
+        id: get-minor-version
+        run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
+
       - name: Download Operate resources from monorepo
-        if: ${{ startsWith(env.GITHUB_REF_NAME, '8.5') || startsWith(env.GITHUB_REF_NAME, '8.6')}}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 6}}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release
@@ -89,7 +97,7 @@ jobs:
           -p "camunda-operate-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
       - name: Download Operate resources
-        if: ${{ !startsWith(env.GITHUB_REF_NAME, '8.5') }}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION < 5 }}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
           -p "camunda-tasklist-$GITHUB_REF_NAME.tar.gz.sha1sum"
 
       - name: Download Operate resources from monorepo
-        if: ${{ startsWith(env.GITHUB_REF_NAME, '8.5') }}
+        if: ${{ startsWith(env.GITHUB_REF_NAME, '8.5') || startsWith(env.GITHUB_REF_NAME, '8.6')}}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,11 +78,11 @@ jobs:
 
       - name: Parse major version number
         id: get-major-version
-        run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MAJOR_VERSION=$major" >> "$GITHUB_OUTPUT"
+        run: echo "$GITHUB_REF_NAME" | (IFS=. read major minor patch && echo "MAJOR_VERSION=$major") >> "$GITHUB_OUTPUT"
 
       - name: Parse minor version number
         id: get-minor-version
-        run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
+        run: echo "$GITHUB_REF_NAME" | (IFS=. read major minor patch && echo "MINOR_VERSION=$minor") >> "$GITHUB_OUTPUT"
 
       - name: Download Operate resources from monorepo
         if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 5 }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
         run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
 
       - name: Download Operate resources from monorepo
-        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 6 }}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 5 }}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
         run: echo "$GITHUB_REF_NAME" | IFS=. read major minor patch && echo "MINOR_VERSION=$minor" >> "$GITHUB_OUTPUT"
 
       - name: Download Operate resources from monorepo
-        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 6}}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 6 }}
         working-directory: ./release-notes-fetcher/tmp
         run: >
           gh release

--- a/release-notes-fetcher/fetch.go
+++ b/release-notes-fetcher/fetch.go
@@ -157,13 +157,13 @@ func main() {
 
 	operateMonoRepoVersion, operateMonoErr := semver.NewVersion("8.5.0")
 	if operateMonoErr != nil {
-		fmt.Println("Error parsing version:", operateMonoErr)
+		log.Error().Stack().Err(operateMonoErr).Msg("Error parsing 8.5.0 version:")
 		return
 	}
 
 	operateCurrentVersion, err1 := semver.NewVersion(camundaAppVersions.Operate)
 	if err1 != nil {
-		fmt.Println("Error parsing version:", err1)
+		log.Error().Stack().Err(err1).Msg("Error parsing operate version:")
 		return
 	}
 

--- a/release-notes-fetcher/fetch.go
+++ b/release-notes-fetcher/fetch.go
@@ -12,13 +12,13 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
+	"github.com/Masterminds/semver/v3"
 )
 
 const RepoOwner = "camunda"
 const CloudRepoOwner = "camunda-cloud"
 const MainRepoName = "camunda-platform"
 const ZeebeRepoName = "camunda"
-const OperateRepoName = "camunda"
 const TasklistRepoName = "tasklist"
 const IdentityRepoName = "identity"
 const ReleaseNotesTemplateFileName = "release-notes-template.txt"
@@ -155,13 +155,36 @@ func main() {
 		camundaAppVersions.Zeebe,
 	)
 
+	operateMonoRepoVersion, operateMonoErr := semver.NewVersion("8.5.0")
+	if operateMonoErr != nil {
+		fmt.Println("Error parsing version:", operateMonoErr)
+		return
+	}
+
+	operateCurrentVersion, err1 := semver.NewVersion(camundaAppVersions.Operate)
+	if err1 != nil {
+		fmt.Println("Error parsing version:", err1)
+		return
+	}
+
+	var OperateRepoTag = ""
+	var OperateRepoName = ""
+	if(operateCurrentVersion.LessThan(operateMonoRepoVersion)) {
+		OperateRepoName = "operate"
+		OperateRepoTag = camundaAppVersions.Operate
+	}else {
+		OperateRepoName = "camunda"
+		OperateRepoTag = "operate-" + camundaAppVersions.Operate
+	}
+
 	operateReleaseNotesContents := GetLatestReleaseContents(
 		ctx,
 		RepoOwner,
 		OperateRepoName,
 		camundaRepoService,
-		"operate-" + camundaAppVersions.Operate,
+		OperateRepoTag,
 	)
+
 
 	tasklistReleaseNotesContents := GetChangelogReleaseContents(
 		ctx,

--- a/release-notes-fetcher/go.mod
+++ b/release-notes-fetcher/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/release-notes-fetcher/go.sum
+++ b/release-notes-fetcher/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=


### PR DESCRIPTION
Adapting:

- release-generation should be triggered with the right pattern
- Operate to get from the correct repo depending on the version