### PR TITLE
Do not attempt to fetch Operate resources from the mono repo for >= 8.6

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -107,7 +107,7 @@ jobs:
         run: echo ${CAMUNDA_RELEASE_NAME} | awk -F '+' '{print $1}' | (IFS=. read major minor patch && echo "MINOR_VERSION=$minor") >> "$GITHUB_OUTPUT"
 
       - name: Download Operate resources from monorepo
-        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION >= 5 }}
+        if: ${{ steps.get-major-version.outputs.MAJOR_VERSION == 8 && steps.get-minor-version.outputs.MINOR_VERSION == 5 }}
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "operate-${OPERATE_GITREF}" \


### PR DESCRIPTION
- due to the single Jar there are no Operate-specific artifacts anymore