### PR TITLE
fix: separate component versions

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ## Image versions ##
 # renovate: datasource=docker depName=camunda/connectors-bundle
-CAMUNDA_CONNECTORS_VERSION=8.5.3
-CAMUNDA_PLATFORM_VERSION=8.5.2
+CAMUNDA_CONNECTORS_VERSION=8.5.5
+CAMUNDA_PLATFORM_VERSION=8.5.6
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.5.4
 # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi

--- a/.env
+++ b/.env
@@ -1,9 +1,22 @@
 ## Image versions ##
 # renovate: datasource=docker depName=camunda/connectors-bundle
 CAMUNDA_CONNECTORS_VERSION=8.5.5
+
+# renovate: datasource=docker depName=camunda/zeebe
 CAMUNDA_PLATFORM_VERSION=8.5.6
+
+# renovate: datasource=docker depName=camunda/identity
+CAMUNDA_IDENTITY_VERSION=8.5.4
+
+# renovate: datasource=docker depName=camunda/operate
+CAMUNDA_OPERATE_VERSION=8.5.5
+
+# renovate: datasource=docker depName=camunda/tasklist
+CAMUNDA_TASKLIST_VERSION=8.5.4
+
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.5.4
+
 # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
 CAMUNDA_WEB_MODELER_VERSION=8.5.6
 # renovate: datasource=docker depName=elasticsearch

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -42,7 +42,7 @@ services:
       - elasticsearch
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -66,7 +66,7 @@ services:
       - elasticsearch
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - identity
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -92,7 +92,7 @@ services:
       - elasticsearch
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"
@@ -213,7 +213,7 @@ services:
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
-    image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
     environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/


### PR DESCRIPTION
A large reason why components aren't getting auto-updated right now are because each component is still tied to eachother, so this PR will split this out. 