### PR TITLE
backport(8.5): disable operate and tasklist csrf (#712)

### DIFF
--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -50,6 +50,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
@@ -74,6 +75,7 @@ services:
       - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe:8080
       - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:


### PR DESCRIPTION
on main, we disabled the CSRF protection by introducing this pull request:
https://github.com/camunda/camunda-platform/pull/807/commits/80e16ad51eb2b714647bec577ec59aa661dea6be

However, this change is not backported to 8.5 which causes the recent issues with renovate not being able to update dependencies in stable/8.5.