### PR TITLE
chore(deps): update tibdex/github-app-token action to v2

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -38,7 +38,8 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          repository: camunda-cloud/identity
+          installation_retrieval_mode: "repository"
+          installation_retrieval_payload: "camunda-cloud/identity"
 
       - name: Set Camunda release tag var
         run: |

--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -27,14 +27,14 @@ jobs:
 
       - name: Generate token for Camunda GitHub org
         id: generate-camunda-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Generate token for Camunda Cloud GitHub org
         id: generate-camunda-cloud-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,14 +22,14 @@ jobs:
 
       - name: Generate token for Camunda GitHub org
         id: generate-camunda-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Generate token for Camunda Cloud GitHub org
         id: generate-camunda-cloud-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,8 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          repository: camunda-cloud/identity
+          installation_retrieval_mode: "repository"
+          installation_retrieval_payload: "camunda-cloud/identity"
 
       - name: Run release notes script
         working-directory: ./release-notes-fetcher

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -22,14 +22,14 @@ jobs:
 
       - name: Generate token for Camunda GitHub org
         id: generate-camunda-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Generate token for Camunda Cloud GitHub org
         id: generate-camunda-cloud-github-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -33,7 +33,8 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          repository: camunda-cloud/identity
+          installation_retrieval_mode: "repository"
+          installation_retrieval_payload: "camunda-cloud/identity"
 
       - name: Run release notes script
         working-directory: ./release-notes-fetcher


### PR DESCRIPTION
This is a forward-port of #791 since I finally figured out how to use v2 with identity and the release-notes fetcher