### PR TITLE
fix: add baseUrl and CSRF flags to stable/8.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ## Image versions ##
 # renovate: datasource=docker depName=camunda/connectors-bundle
-CAMUNDA_CONNECTORS_VERSION=8.4.8
+CAMUNDA_CONNECTORS_VERSION=8.4.9
 
 # renovate: datasource=docker depName=camunda/zeebe
 CAMUNDA_PLATFORM_VERSION=8.4.6

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -49,6 +49,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
@@ -72,6 +73,7 @@ services:
       - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
+      - CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED=false
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
@@ -95,6 +97,7 @@ services:
       - ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=zeebe:26500
       - ZEEBE_CLIENT_SECURITY_PLAINTEXT=true
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
+      - CAMUNDA_OPERATE_CLIENT_BASEURL=http://operate:8080
       - CAMUNDA_OPERATE_CLIENT_USERNAME=demo
       - CAMUNDA_OPERATE_CLIENT_PASSWORD=demo
 #       - CAMUNDA_CLIENT_MODE=simple

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -100,11 +100,6 @@ services:
       - CAMUNDA_OPERATE_CLIENT_BASEURL=http://operate:8080
       - CAMUNDA_OPERATE_CLIENT_USERNAME=demo
       - CAMUNDA_OPERATE_CLIENT_PASSWORD=demo
-#       - CAMUNDA_CLIENT_MODE=simple
-#       - CAMUNDA_CLIENT_AUTH_USERNAME=demo
-#       - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
-#       - CAMUNDA_CLIENT_OPERATE_BASE_URL=http://operate:8080
-#       - CAMUNDA_CLIENT_TASKLIST_BASE_URL=http://tasklist:8080
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:

--- a/docker-compose-core.yaml
+++ b/docker-compose-core.yaml
@@ -97,6 +97,11 @@ services:
       - CAMUNDA_OPERATE_CLIENT_URL=http://operate:8080
       - CAMUNDA_OPERATE_CLIENT_USERNAME=demo
       - CAMUNDA_OPERATE_CLIENT_PASSWORD=demo
+#       - CAMUNDA_CLIENT_MODE=simple
+#       - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+#       - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+#       - CAMUNDA_CLIENT_OPERATE_BASE_URL=http://operate:8080
+#       - CAMUNDA_CLIENT_TASKLIST_BASE_URL=http://tasklist:8080
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:


### PR DESCRIPTION
Related to https://github.com/camunda-community-hub/spring-zeebe/issues/933

Theres an issue in spring-zeebe sdk which requires this additional env var set for 8.4