### PR TITLE
chore: update release-notes-fetcher versions

### DIFF
--- a/release-notes-fetcher/config/release-notes-fetcher-camunda-8.2.yaml
+++ b/release-notes-fetcher/config/release-notes-fetcher-camunda-8.2.yaml
@@ -1,6 +1,6 @@
 gitRef:
-  global: 8.2.29
-  operate: 8.2.28
-  identity: 8.2.29
-  tasklist: 8.2.29
-  zeebe: 8.2.29
+  global: 8.2.31
+  operate: 8.2.30
+  identity: 8.2.31
+  tasklist: 8.2.31
+  zeebe: 8.2.31

--- a/release-notes-fetcher/config/release-notes-fetcher-camunda-8.3.yaml
+++ b/release-notes-fetcher/config/release-notes-fetcher-camunda-8.3.yaml
@@ -1,6 +1,6 @@
 gitRef:
-  global: 8.3.12
-  operate: 8.3.13
+  global: 8.3.15
+  operate:
   identity:
-  tasklist:
+  tasklist: 8.3.16
   zeebe:

--- a/release-notes-fetcher/config/release-notes-fetcher-camunda-8.4.yaml
+++ b/release-notes-fetcher/config/release-notes-fetcher-camunda-8.4.yaml
@@ -1,6 +1,6 @@
 gitRef:
-  global: 8.4.8
+  global: 8.4.11
   operate: 8.4.10
   identity:
-  tasklist:
+  tasklist: 8.4.12
   zeebe:

--- a/release-notes-fetcher/config/release-notes-fetcher-camunda-8.5.yaml
+++ b/release-notes-fetcher/config/release-notes-fetcher-camunda-8.5.yaml
@@ -1,6 +1,6 @@
 gitRef:
-  global: 8.5.4
-  operate: 8.5.4
-  identity: 8.5.3
-  tasklist: 8.5.3
-  zeebe: 8.5.4
+  global: 8.5.7
+  operate: 8.5.6
+  identity: 8.5.5
+  tasklist: 8.5.7
+  zeebe: 8.5.7

--- a/release-notes-fetcher/config/release-notes-fetcher-camunda-8.6.yaml
+++ b/release-notes-fetcher/config/release-notes-fetcher-camunda-8.6.yaml
@@ -1,5 +1,5 @@
 gitRef:
-  global: 8.6.0-alpha4
+  global: 8.6.0-alpha5
   operate:
   identity:
   tasklist:


### PR DESCRIPTION
the release notes fetcher is grabbing incorrect release notes due to the yaml files not having been updated.