### PR TITLE
chore(deps): update camunda/web-modeler docker tag to v8.5.12 (stable/8.5)

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ CAMUNDA_TASKLIST_VERSION=8.5.8
 CAMUNDA_OPTIMIZE_VERSION=8.5.6
 
 # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
-CAMUNDA_WEB_MODELER_VERSION=8.5.11
+CAMUNDA_WEB_MODELER_VERSION=8.5.12
 
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.14.0


### PR DESCRIPTION
Updating manually since Renovate did not automatically create a PR for the new version.