### PR TITLE
fix: use correct Tasklist version in release-generation

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -94,10 +94,10 @@ jobs:
             -p "camunda-zeebe-${ZEEBE_GITREF}.tar.gz.sha1sum" \
             -p "camunda-zeebe-${ZEEBE_GITREF}.zip" \
             -p "camunda-zeebe-${ZEEBE_GITREF}.zip.sha1sum" \
-            -p "camunda-tasklist-${ZEEBE_GITREF}.zip" \
-            -p "camunda-tasklist-${ZEEBE_GITREF}.zip.sha1sum" \
-            -p "camunda-tasklist-${ZEEBE_GITREF}.tar.gz" \
-            -p "camunda-tasklist-${ZEEBE_GITREF}.tar.gz.sha1sum"
+            -p "camunda-tasklist-${TASKLIST_GITREF}.zip" \
+            -p "camunda-tasklist-${TASKLIST_GITREF}.zip.sha1sum" \
+            -p "camunda-tasklist-${TASKLIST_GITREF}.tar.gz" \
+            -p "camunda-tasklist-${TASKLIST_GITREF}.tar.gz.sha1sum"
 
       - name: Parse major version number
         id: get-major-version


### PR DESCRIPTION
As discussed in [Slack](https://camunda.slack.com/archives/C08MRKHJ0CD/p1746517143674509)
Tasklist artifacts are not always pulled into camunda-platform releases for pre 8.6 versions
The problem is that the workflow is assuming that Zeebe and Tasklist have the same versions, which is not always true