### PR TITLE
chore: update identity organization

### DIFF
--- a/.github/workflows/release-generation.yaml
+++ b/.github/workflows/release-generation.yaml
@@ -39,7 +39,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_retrieval_mode: "repository"
-          installation_retrieval_payload: "camunda-cloud/identity"
+          installation_retrieval_payload: "camunda/identity"
 
       - name: Set Camunda release tag var
         run: |
@@ -137,7 +137,7 @@ jobs:
         working-directory: ./release-notes-fetcher/tmp
         run: |
           gh release download "${IDENTITY_GITREF}" \
-            -R camunda-cloud/identity \
+            -R camunda/identity \
             -p "camunda-identity-${IDENTITY_GITREF}.tar.gz" \
             -p "camunda-identity-${IDENTITY_GITREF}.tar.gz.sha1sum" \
             -p "camunda-identity-${IDENTITY_GITREF}.zip" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_retrieval_mode: "repository"
-          installation_retrieval_payload: "camunda-cloud/identity"
+          installation_retrieval_payload: "camunda/identity"
 
       - name: Run release notes script
         working-directory: ./release-notes-fetcher
@@ -118,7 +118,7 @@ jobs:
         run: >
           gh release
           download "$GITHUB_REF_NAME"
-          -R camunda-cloud/identity
+          -R camunda/identity
           -p "camunda-identity-$GITHUB_REF_NAME.tar.gz"
           -p "camunda-identity-$GITHUB_REF_NAME.tar.gz.sha1sum"
           -p "camunda-identity-$GITHUB_REF_NAME.zip"


### PR DESCRIPTION
This pull request updates the repository references for the Camunda Identity project in the GitHub Actions workflows. All references to the old repository name `camunda-cloud/identity` are changed to the new repository name `camunda/identity` to ensure that release generation and release workflows interact with the correct repository.

Repository reference updates:

* Updated `installation_retrieval_payload` and `gh release download` commands in `.github/workflows/release-generation.yaml` to use `camunda/identity` instead of `camunda-cloud/identity`. [[1]](diffhunk://#diff-62a80afb587296490a74496a64a7fb4aa6dcc0ed72c7b87f9c44b91d4e83ab42L42-R42) [[2]](diffhunk://#diff-62a80afb587296490a74496a64a7fb4aa6dcc0ed72c7b87f9c44b91d4e83ab42L140-R140)
* Updated `installation_retrieval_payload` and `gh release download` commands in `.github/workflows/release.yaml` to use `camunda/identity` instead of `camunda-cloud/identity`. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL37-R37) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL121-R121)

NOTE: This must be merged once the transfer is completed

Checkout for context: 
- camunda/team-infrastructure#934